### PR TITLE
Use content.identifier for attachment references

### DIFF
--- a/src/pydantic_ai_gepa/input_type.py
+++ b/src/pydantic_ai_gepa/input_type.py
@@ -55,7 +55,6 @@ class _AttachmentRegistry:
         self.attachments: list[AttachmentContent] = []
         self.placeholders: list[str] = []
         self._placeholders: dict[int, str] = {}
-        self._type_counts: dict[str, int] = {}
 
     def register(self, content: AttachmentContent) -> str:
         key = id(content)
@@ -64,10 +63,8 @@ class _AttachmentRegistry:
             return existing
 
         label = self._label_for(content)
-        index = self._type_counts.get(label, 0) + 1
-        self._type_counts[label] = index
-
-        ref = f"{label}{index}"
+        # Use the content's stable identifier (hash-based) for consistent references
+        ref = content.identifier
         placeholder = f'<{label} ref="{ref}"/>'
         self.attachments.append(content)
         self.placeholders.append(placeholder)

--- a/tests/test_signature_user_content.py
+++ b/tests/test_signature_user_content.py
@@ -40,9 +40,9 @@ def test_user_content_with_multimodal_resources() -> None:
     text_content = user_content[2]
     assert text_content == snapshot("""\
 <gallery>
-  <item><image ref="image1"/></item>
+  <item><image ref="b86daf"/></item>
   <item>Provide a comparison of the screenshots.</item>
-  <item><image ref="image2"/></item>
+  <item><image ref="a98844"/></item>
   <item>Highlight any mismatched UI states.</item>
 </gallery>
 
@@ -90,12 +90,12 @@ ReferenceModel
     text_content = user_content[1]
     assert text_content == snapshot("""\
 <reference>
-  <attachment><image ref="image1"/></attachment>
+  <attachment><image ref="cd6702"/></attachment>
   <remark>Primary capture.</remark>
 </reference>
 
 <repeated>
   <item>Revisit the earlier capture here:</item>
-  <item><image ref="image1"/></item>
+  <item><image ref="cd6702"/></item>
 </repeated>\
 """)


### PR DESCRIPTION
## Summary

- Use `content.identifier` property for attachment XML references instead of counter-based IDs
- References now use stable 6-character hashes (e.g., `<image ref="cd6702"/>`) instead of sequential counters (`<image ref="image1"/>`)
- Remove unused `_type_counts` tracking

## Motivation

pydantic-ai's multimodal types (`BinaryContent`, `ImageUrl`, etc.) all have an `identifier` property that provides a stable hash-based identifier. Using this instead of counter-based refs:

1. Makes references consistent with the `_identifier` field on the actual content objects
2. Provides stable identifiers that don't change based on registration order
3. Improves traceability between XML references and actual multimodal content

## Test plan

- [x] `uv run pyright` - 0 errors
- [x] `uv run pytest` - 141 tests pass
- [x] Updated inline snapshots for new reference format

🤖 Generated with [Claude Code](https://claude.com/claude-code)