### PR TITLE
Only offer trace tools when span files exist for the run

### DIFF
--- a/src/pydantic_ai_gepa/gepa_graph/proposal/instruction.py
+++ b/src/pydantic_ai_gepa/gepa_graph/proposal/instruction.py
@@ -226,6 +226,15 @@ def _skills_tools_enabled(component_toolsets: Sequence[AbstractToolset[None]]) -
     )
 
 
+def _trace_tools_enabled(component_toolsets: Sequence[AbstractToolset[None]]) -> bool:
+    # Trace tools are only attached when the run has span files on disk; their
+    # absence means the adapter produced no instrumented traces.
+    return any(
+        _toolset_has_tool(toolset, "run_python_repl")
+        for toolset in component_toolsets
+    )
+
+
 def _journal_tools_enabled(component_toolsets: Sequence[AbstractToolset[None]]) -> bool:
     return any(
         _toolset_has_tool(toolset, "read_journal_entries")
@@ -363,6 +372,11 @@ class InstructionProposalGenerator:
             reflective_data=reflective_data,
             components=actionable,
             example_bank=example_bank,
+            traces_on_disk=(
+                _trace_tools_enabled(component_toolsets)
+                if component_toolsets is not None
+                else True
+            ),
         )
 
         try:
@@ -475,6 +489,7 @@ class InstructionProposalGenerator:
         reflective_data: ReflectiveDataset,
         components: Sequence[str],
         example_bank: InMemoryExampleBank | None = None,
+        traces_on_disk: bool = True,
     ) -> Sequence[UserContent]:
         selection_mode = not components
         lines: list[Any] = [
@@ -714,7 +729,11 @@ class InstructionProposalGenerator:
                 "## Production traces from student agent runs",
                 "",
                 "The prompt includes compact reflection examples with scores, success flags, evaluator feedback, messages, and tool definitions.",
-                "Full execution spans are available separately on disk as OTel/Logfire span JSON and should be inspected through the structured trace helpers in `run_python_repl`.",
+                (
+                    "Full execution spans are available separately on disk as OTel/Logfire span JSON and should be inspected through the structured trace helpers in `run_python_repl`."
+                    if traces_on_disk
+                    else "No execution span files exist for this run: the adapter under optimization performs no instrumented model calls. The reflection records in this prompt are the complete evidence."
+                ),
                 "",
             ]
         )
@@ -734,34 +753,52 @@ class InstructionProposalGenerator:
 
         failed_records = total_records - success_records
 
-        lines.extend(
-            [
-                "",
-                "## Execution Traces Available for Analysis",
-                "",
-                f"{total_records} traces available from the execution: {success_records} succeeded, {failed_records} failed.",
-                "The OTel/Logfire spans are stored on disk as `traces/traces.jsonl`.",
-                "You must use the `run_python_repl(python_code: str)` tool to write and execute python scripts for trace analysis. Prefer structured helpers such as `trace_overview`, `query_traces`, `view_trace`, `view_spans`, `search_trace`, and `search_span`; drop down to raw file helpers only when needed.",
-                f"You may also use `spawn_agent(instructions: str)` to spawn a Recursive Language Model (RLM) sub-agent to deeply inspect specific traces for semantic failures. The proposal step has a shared limit of {self._max_spawned_agents} spawned sub-agents, including recursive child spawns.",
-                "",
-                "**IMPORTANT: Prompt Caching & State Management**",
-                "Your python REPL is stateful. Variables assigned in one script will persist to the next.",
-                "To leverage LLM prompt caching efficiently, you should build up state in your Python REPL rather than returning huge strings (like full traces) to your context window.",
-                "If your context window becomes bloated, use the `clear_message_history` tool. This wipes your message history to free up tokens, but your Python REPL variables remain intact!",
-                "Only use `clear_message_history` sparingly when absolutely necessary to avoid breaking the prompt cache.",
-                "",
-                MONTY_REPL_PROMPT_GUIDANCE,
-                "",
-            ]
-        )
+        if traces_on_disk:
+            lines.extend(
+                [
+                    "",
+                    "## Execution Traces Available for Analysis",
+                    "",
+                    f"{total_records} traces available from the execution: {success_records} succeeded, {failed_records} failed.",
+                    "The OTel/Logfire spans are stored on disk as `traces/traces.jsonl`.",
+                    "You must use the `run_python_repl(python_code: str)` tool to write and execute python scripts for trace analysis. Prefer structured helpers such as `trace_overview`, `query_traces`, `view_trace`, `view_spans`, `search_trace`, and `search_span`; drop down to raw file helpers only when needed.",
+                    f"You may also use `spawn_agent(instructions: str)` to spawn a Recursive Language Model (RLM) sub-agent to deeply inspect specific traces for semantic failures. The proposal step has a shared limit of {self._max_spawned_agents} spawned sub-agents, including recursive child spawns.",
+                    "",
+                    "**IMPORTANT: Prompt Caching & State Management**",
+                    "Your python REPL is stateful. Variables assigned in one script will persist to the next.",
+                    "To leverage LLM prompt caching efficiently, you should build up state in your Python REPL rather than returning huge strings (like full traces) to your context window.",
+                    "If your context window becomes bloated, use the `clear_message_history` tool. This wipes your message history to free up tokens, but your Python REPL variables remain intact!",
+                    "Only use `clear_message_history` sparingly when absolutely necessary to avoid breaking the prompt cache.",
+                    "",
+                    MONTY_REPL_PROMPT_GUIDANCE,
+                    "",
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    "## No execution traces exist for this run",
+                    "",
+                    f"{total_records} reflection records: {success_records} succeeded, {failed_records} failed.",
+                    "There are no span files and no trace tools for this run. The reflection records above — scores, evaluator feedback, and any per-component evidence — are the complete evidence. Do not search for traces.jsonl or attempt trace analysis; reason directly from the records.",
+                    "",
+                ]
+            )
 
         lines.extend(
             [
                 "",
                 "### Analysis guidance",
-                "- Use `run_python_repl` with structured trace helpers to aggregate errors or find common failure modes across `traces.jsonl` without returning full traces.",
-                "- Start with `trace_overview()`, use `query_traces(...)` to identify trace IDs, and then use `view_trace(...)`, `view_spans(...)`, `search_trace(...)`, or `search_span(...)` for focused evidence.",
-                "- Use `spawn_agent` to understand *why* a specific trace failed if the python analysis is insufficient.",
+                *(
+                    [
+                        "- Use `run_python_repl` with structured trace helpers to aggregate errors or find common failure modes across `traces.jsonl` without returning full traces.",
+                        "- Start with `trace_overview()`, use `query_traces(...)` to identify trace IDs, and then use `view_trace(...)`, `view_spans(...)`, `search_trace(...)`, or `search_span(...)` for focused evidence.",
+                        "- Use `spawn_agent` to understand *why* a specific trace failed if the python analysis is insufficient.",
+                    ]
+                    if traces_on_disk
+                    else []
+                ),
                 "- What failure patterns repeat across runs?",
                 "- Are components misaligned (e.g., instructions referencing tools that don't exist)?",
                 "- Which successful patterns should be preserved or extended?",

--- a/src/pydantic_ai_gepa/gepa_graph/proposal/instruction.py
+++ b/src/pydantic_ai_gepa/gepa_graph/proposal/instruction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logfire
 from dataclasses import dataclass
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -438,7 +439,15 @@ class InstructionProposalGenerator:
 
         except InspectionAborted:
             raise
-        except Exception:
+        except Exception as error:
+            # An empty proposal is a silent no-op round: the engine skips
+            # evaluation and the reflector re-derives the same work next
+            # iteration with no idea it was lost. Make the cause loud.
+            logfire.warning(
+                "Instruction proposal failed; returning empty proposal",
+                error_type=type(error).__name__,
+                error=str(error)[:2000],
+            )
             return ProposalResult(
                 texts={},
                 component_metadata={},

--- a/src/pydantic_ai_gepa/gepa_graph/steps/reflect.py
+++ b/src/pydantic_ai_gepa/gepa_graph/steps/reflect.py
@@ -143,21 +143,29 @@ async def reflect_step(ctx: StepContext[GepaState, GepaDeps, None]) -> Iteration
     with open(components_file, "w", encoding="utf-8") as f:
         json.dump({k: v.text for k, v in parent.components.items()}, f, indent=2)
 
-    from ..proposal.trace_tools import create_trace_toolset
+    # Only offer trace tools when span files actually exist for this candidate.
+    # Custom adapters whose rollouts make no instrumented model calls produce
+    # no spans; handing the reflector trace tools that point at nothing sends
+    # it hunting for files that will never appear.
+    candidate_traces_file = Path(
+        f".gepa_cache/runs/{state.run_id}/candidates/{parent_idx}/traces/traces.jsonl"
+    )
+    if candidate_traces_file.exists():
+        from ..proposal.trace_tools import create_trace_toolset
 
-    max_spawned_agents = (
-        state.config.reflection_config.max_spawned_agents
-        if state.config.reflection_config
-        else DEFAULT_MAX_SPAWNED_AGENTS
-    )
-    component_toolsets.append(
-        create_trace_toolset(
-            state.run_id,
-            parent_idx,
-            reflection_model,
-            max_spawned_agents=max_spawned_agents,
+        max_spawned_agents = (
+            state.config.reflection_config.max_spawned_agents
+            if state.config.reflection_config
+            else DEFAULT_MAX_SPAWNED_AGENTS
         )
-    )
+        component_toolsets.append(
+            create_trace_toolset(
+                state.run_id,
+                parent_idx,
+                reflection_model,
+                max_spawned_agents=max_spawned_agents,
+            )
+        )
 
     if state.config.component_selector == "reflection":
         components_to_update = None

--- a/tests/gepa_graph/steps/test_reflect_step.py
+++ b/tests/gepa_graph/steps/test_reflect_step.py
@@ -363,9 +363,12 @@ async def test_reflect_step_applies_config_sampler() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reflect_step_passes_subagent_limit_to_trace_toolset(monkeypatch) -> None:
+async def test_reflect_step_passes_subagent_limit_to_trace_toolset(
+    monkeypatch, tmp_path
+) -> None:
     from pydantic_ai import FunctionToolset
 
+    monkeypatch.chdir(tmp_path)
     captured_limits: list[int] = []
 
     def fake_create_trace_toolset(
@@ -400,6 +403,15 @@ async def test_reflect_step_passes_subagent_limit_to_trace_toolset(monkeypatch) 
         proposal_generator=generator,
     )
     ctx = _ctx(state, deps)
+
+    # Trace tools are only offered when span files exist for the candidate.
+    from pathlib import Path
+
+    traces_file = Path(
+        f".gepa_cache/runs/{state.run_id}/candidates/0/traces/traces.jsonl"
+    )
+    traces_file.parent.mkdir(parents=True, exist_ok=True)
+    traces_file.write_text("{}\n")
 
     await reflect_step(ctx)
 


### PR DESCRIPTION
Custom adapters whose rollouts make no instrumented model calls emit no OTel spans, so `traces/traces.jsonl` is never written — but the reflector was unconditionally handed trace-navigation tools and a prompt asserting spans exist on disk. Observed in a live run: the reflector spent multiple proposal rounds hunting for trace files and journaling about permission-denied paths instead of doing policy work.

- `reflect.py`: attach the trace toolset only when the candidate has a `traces.jsonl` on disk
- `instruction.py`: `traces_on_disk` threads into the prompt builder; when false, the prompt states the reflection records are the complete evidence and the trace-analysis guidance is omitted
- test updated to create the span file it asserts against

133/133 gepa_graph tests pass.