### PR TITLE
Add CodingAgentEngine with caller-supplied proposer

### DIFF
--- a/src/pydantic_ai_gepa/engines/__init__.py
+++ b/src/pydantic_ai_gepa/engines/__init__.py
@@ -18,11 +18,13 @@ from .registry import (
     unregister_engine,
 )
 from .gepa_engine import GepaEngine
+from .coding_agent_engine import CodingAgentEngine, Proposer, ReflectionContext
 
 __all__ = [
     "BudgetExhausted",
     "BudgetTracker",
     "CandidateEvaluation",
+    "CodingAgentEngine",
     "EngineConfig",
     "EngineEvent",
     "EngineFactory",
@@ -30,6 +32,8 @@ __all__ = [
     "GepaEngine",
     "OptimizationEngine",
     "OptimizationTask",
+    "Proposer",
+    "ReflectionContext",
     "get_engine",
     "list_engines",
     "register_engine",

--- a/src/pydantic_ai_gepa/engines/coding_agent_engine.py
+++ b/src/pydantic_ai_gepa/engines/coding_agent_engine.py
@@ -1,0 +1,404 @@
+"""An in-process managed reflection loop driven by a caller-supplied proposer."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeAlias, cast
+
+from pydantic_evals import Case
+
+from ..evaluation import EvaluationRecord, evaluate_candidate_dataset
+from ..gepa_graph.models import CandidateMap
+from .base import (
+    BudgetExhausted,
+    BudgetTracker,
+    EngineConfig,
+    EngineEvent,
+    EngineResult,
+    OptimizationTask,
+    _aggregate_side_info,
+)
+from .registry import register_engine
+
+
+@dataclass(frozen=True, slots=True)
+class ReflectionContext:
+    """Evidence supplied to a coding agent before it proposes a revision."""
+
+    candidate: CandidateMap
+    minibatch_records: list[EvaluationRecord]
+    report: str
+    iteration: int
+    side_info: dict[str, Any]
+
+
+Proposer: TypeAlias = Callable[[ReflectionContext], Awaitable[CandidateMap]]
+
+
+class CodingAgentEngine:
+    """Optimize with a caller-supplied coding agent under a shared budget.
+
+    The library owns minibatch sampling, evaluation, and monotonic candidate
+    selection.  The caller's ``propose`` callback only receives failure
+    evidence and returns a candidate to test on that same minibatch.
+    """
+
+    name = "coding_agent"
+
+    def __init__(self, config: EngineConfig) -> None:
+        """Read the required asynchronous proposal callback from configuration."""
+        propose = config.engine_config.get("propose")
+        if not callable(propose):
+            raise TypeError(
+                "engine_config['propose'] must be a callable async callback that "
+                "accepts ReflectionContext and returns a CandidateMap."
+            )
+        self._propose = cast(Proposer, propose)
+        self._engine_config = config.engine_config
+
+    async def run(
+        self,
+        task: OptimizationTask,
+        config: EngineConfig,
+        budget: BudgetTracker,
+    ) -> EngineResult:
+        """Run managed baseline/reflection rounds and return the best candidate."""
+        budget.check()
+
+        minibatch_size = self._positive_int_option("minibatch_size", 5)
+        concurrency = self._positive_int_option("concurrency", 5)
+        max_proposals = self._positive_int_option("max_proposals_per_run", 10)
+        failure_threshold = float(self._option("failure_threshold", 0.999))
+
+        best = _copy_candidate(await task.seed_candidate())
+        train_loader = await task.train_loader()
+        all_ids = list(await train_loader.all_ids())
+        starting_spend = budget.spent
+        engine_budget = BudgetTracker(config.max_metric_calls)
+        history: list[EngineEvent] = []
+        epoch = 0
+        iterations = 0
+        proposals = 0
+        stop_reason = "completed"
+
+        while (
+            (config.max_iterations is None or iterations < config.max_iterations)
+            and not budget.exhausted
+            and not engine_budget.exhausted
+            and proposals < max_proposals
+        ):
+            minibatch_ids = _sample_minibatch(
+                all_ids,
+                size=minibatch_size,
+                seed=config.seed,
+                epoch=epoch,
+            )
+            epoch += 1
+            minibatch = await train_loader.fetch(minibatch_ids)
+            baseline_records = await self._evaluate_minibatch(
+                task=task,
+                candidate=best,
+                minibatch=minibatch,
+                concurrency=concurrency,
+            )
+            iterations += 1
+            if not self._spend_or_record_overshoot(
+                budget=budget,
+                engine_budget=engine_budget,
+                history=history,
+                stage="baseline_minibatch",
+                records=baseline_records,
+            ):
+                stop_reason = "budget_overshoot"
+                break
+
+            baseline_score = _mean_score(baseline_records)
+            if (
+                config.stop_at_score is not None
+                and baseline_score >= config.stop_at_score
+            ):
+                stop_reason = "stop_at_score"
+                break
+            if budget.exhausted or engine_budget.exhausted:
+                stop_reason = "budget_exhausted"
+                break
+
+            failures = [
+                record
+                for record in baseline_records
+                if record.score < failure_threshold
+            ]
+            if not failures:
+                history.append(
+                    EngineEvent(
+                        kind="clean_minibatch",
+                        data={
+                            "iteration": iterations,
+                            "mean_score": baseline_score,
+                            "minibatch_case_ids": [
+                                record.case_id for record in baseline_records
+                            ],
+                        },
+                    )
+                )
+                continue
+
+            context = ReflectionContext(
+                candidate=_copy_candidate(best),
+                minibatch_records=failures,
+                report=_format_failure_report(baseline_records, failure_threshold),
+                iteration=iterations,
+                side_info=_aggregate_side_info(baseline_records),
+            )
+            proposal = await self._propose(context)
+            proposals += 1
+
+            try:
+                proposal_records = await self._evaluate_minibatch(
+                    task=task,
+                    candidate=proposal,
+                    minibatch=minibatch,
+                    concurrency=concurrency,
+                )
+            except Exception as exc:
+                raise RuntimeError("Coding-agent proposal evaluation failed.") from exc
+
+            if not self._spend_or_record_overshoot(
+                budget=budget,
+                engine_budget=engine_budget,
+                history=history,
+                stage="proposal_minibatch",
+                records=proposal_records,
+            ):
+                stop_reason = "budget_overshoot"
+                break
+
+            proposal_score = _mean_score(proposal_records)
+            comparison = {
+                "iteration": iterations,
+                "baseline_score": baseline_score,
+                "proposal_score": proposal_score,
+                "delta": proposal_score - baseline_score,
+                "minibatch_case_ids": [record.case_id for record in baseline_records],
+            }
+            if proposal_score > baseline_score:
+                best = _copy_candidate(proposal)
+                history.append(EngineEvent(kind="accepted", data=comparison))
+            else:
+                history.append(EngineEvent(kind="rejected", data=comparison))
+
+        if (budget.exhausted or engine_budget.exhausted) and stop_reason == "completed":
+            stop_reason = "budget_exhausted"
+        elif proposals >= max_proposals and stop_reason == "completed":
+            stop_reason = "max_proposals_per_run"
+        elif (
+            config.max_iterations is not None
+            and iterations >= config.max_iterations
+            and stop_reason == "completed"
+        ):
+            stop_reason = "max_iterations"
+
+        final_score, final_evaluation_charged = await self._score_final_candidate(
+            task=task,
+            candidate=best,
+            budget=budget,
+            engine_budget=engine_budget,
+            history=history,
+        )
+        history.append(
+            EngineEvent(
+                kind="summary",
+                data={
+                    "iterations": iterations,
+                    "proposals": proposals,
+                    "stop_reason": stop_reason,
+                    "final_evaluation_charged": final_evaluation_charged,
+                },
+            )
+        )
+        return EngineResult(
+            engine=self.name,
+            best_candidate=best,
+            best_score=final_score,
+            num_metric_calls=budget.spent - starting_spend,
+            history=history,
+        )
+
+    async def _evaluate_minibatch(
+        self,
+        *,
+        task: OptimizationTask,
+        candidate: CandidateMap,
+        minibatch: Sequence[Case[Any, Any, Any]],
+        concurrency: int,
+    ) -> list[EvaluationRecord]:
+        """Evaluate one candidate on the explicitly selected minibatch."""
+        return await evaluate_candidate_dataset(
+            agent=task.agent,
+            metric=task.metric,
+            dataset=minibatch,
+            candidate=candidate,
+            concurrency=concurrency,
+            input_type=task.input_type,
+            case_factory=task.case_factory,
+            skills_fs=task.skills_fs,
+            skills_capabilities=task.skills_capabilities,
+            capture_traces=True,
+        )
+
+    async def _score_final_candidate(
+        self,
+        *,
+        task: OptimizationTask,
+        candidate: CandidateMap,
+        budget: BudgetTracker,
+        engine_budget: BudgetTracker,
+        history: list[EngineEvent],
+    ) -> tuple[float, bool]:
+        """Score the winner on the valset and charge that fair comparison.
+
+        The score is evaluated before spending so it remains available for the
+        result when the final comparison itself would exceed the shared budget.
+        In that overshoot case the budget remains unchanged and the event makes
+        the uncharged evaluation explicit to a composing caller.
+        """
+        final_evaluation = await task.evaluate(candidate, budget=None)
+        if final_evaluation.num_cases > engine_budget.remaining:
+            history.append(
+                EngineEvent(
+                    kind="budget_overshoot",
+                    message="Final valset evaluation exceeded the engine metric-call budget.",
+                    data={
+                        "stage": "final_valset",
+                        "requested": final_evaluation.num_cases,
+                        "budget_remaining": budget.remaining,
+                        "engine_budget_remaining": engine_budget.remaining,
+                    },
+                )
+            )
+            return final_evaluation.score, False
+        try:
+            budget.spend(final_evaluation.num_cases)
+        except BudgetExhausted:
+            history.append(
+                EngineEvent(
+                    kind="budget_overshoot",
+                    message="Final valset evaluation exceeded the shared metric-call budget.",
+                    data={
+                        "stage": "final_valset",
+                        "requested": final_evaluation.num_cases,
+                        "budget_remaining": budget.remaining,
+                        "engine_budget_remaining": engine_budget.remaining,
+                    },
+                )
+            )
+            return final_evaluation.score, False
+        engine_budget.spend(final_evaluation.num_cases)
+        return final_evaluation.score, True
+
+    def _spend_or_record_overshoot(
+        self,
+        *,
+        budget: BudgetTracker,
+        engine_budget: BudgetTracker,
+        history: list[EngineEvent],
+        stage: str,
+        records: Sequence[EvaluationRecord],
+    ) -> bool:
+        """Charge an evaluation or record the budget overshoot that stops it."""
+        if len(records) > engine_budget.remaining:
+            history.append(
+                EngineEvent(
+                    kind="budget_overshoot",
+                    message="Minibatch evaluation exceeded the engine metric-call budget.",
+                    data={
+                        "stage": stage,
+                        "requested": len(records),
+                        "budget_remaining": budget.remaining,
+                        "engine_budget_remaining": engine_budget.remaining,
+                    },
+                )
+            )
+            return False
+        try:
+            budget.spend(len(records))
+        except BudgetExhausted:
+            history.append(
+                EngineEvent(
+                    kind="budget_overshoot",
+                    message="Minibatch evaluation exceeded the shared metric-call budget.",
+                    data={
+                        "stage": stage,
+                        "requested": len(records),
+                        "budget_remaining": budget.remaining,
+                        "engine_budget_remaining": engine_budget.remaining,
+                    },
+                )
+            )
+            return False
+        engine_budget.spend(len(records))
+        return True
+
+    def _option(self, name: str, default: Any) -> Any:
+        """Return a coding-agent option from the engine-specific configuration."""
+        return self._engine_config.get(name, default)
+
+    def _positive_int_option(self, name: str, default: int) -> int:
+        """Read an engine count option while rejecting invalid runtime settings."""
+        value = self._option(name, default)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"engine_config[{name!r}] must be a positive integer.")
+        return value
+
+
+def _sample_minibatch(
+    all_ids: Sequence[Any],
+    *,
+    size: int,
+    seed: int,
+    epoch: int,
+) -> list[Any]:
+    """Return a deterministic, without-replacement minibatch for one epoch."""
+    return random.Random(seed + epoch).sample(list(all_ids), k=min(size, len(all_ids)))
+
+
+def _mean_score(records: Sequence[EvaluationRecord]) -> float:
+    """Return the mean score for an evaluated minibatch."""
+    return sum(record.score for record in records) / len(records) if records else 0.0
+
+
+def _copy_candidate(candidate: CandidateMap) -> CandidateMap:
+    """Isolate retained candidates from proposer-side mutation."""
+    return {
+        name: component.model_copy(deep=True) for name, component in candidate.items()
+    }
+
+
+def _format_failure_report(
+    records: Sequence[EvaluationRecord], threshold: float
+) -> str:
+    """Format failed records in the managed CLI's markdown report style."""
+    lines = ["# Eval report", ""]
+    failures = [record for record in records if record.score < threshold]
+    if not failures:
+        lines.append("Every case in this minibatch passed; nothing to act on.")
+        return "\n".join(lines)
+
+    lines.append(
+        f"{len(failures)} of {len(records)} case(s) underperformed "
+        f"(score < {threshold}). Review per-case feedback and revise the candidate.\n"
+    )
+    for record in failures:
+        lines.append(f"## {record.case_id} — score {record.score:.3f}")
+        if record.feedback:
+            lines.extend(["", record.feedback.rstrip()])
+        lines.append("")
+    return "\n".join(lines)
+
+
+register_engine(CodingAgentEngine.name, CodingAgentEngine, replace=True)
+
+
+__all__ = ["CodingAgentEngine", "Proposer", "ReflectionContext"]

--- a/tests/engines/test_coding_agent_engine.py
+++ b/tests/engines/test_coding_agent_engine.py
@@ -1,0 +1,176 @@
+"""Coverage for the caller-proposed coding-agent optimization engine."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+from pydantic_evals import Case
+
+from pydantic_ai_gepa.engines import (
+    BudgetTracker,
+    CodingAgentEngine,
+    EngineConfig,
+    OptimizationTask,
+    ReflectionContext,
+    get_engine,
+)
+from pydantic_ai_gepa.gepa_graph.models import CandidateMap, ComponentValue
+from pydantic_ai_gepa.types import MetricResult, RolloutOutput
+
+
+def _task(*, case_count: int = 3) -> OptimizationTask:
+    """Build a TestModel task whose metric observes the applied instructions."""
+    agent = Agent(TestModel(custom_output_text="response"), instructions="seed")
+    cases = [
+        Case(name=f"case-{index}", inputs="input", expected_output="response")
+        for index in range(case_count)
+    ]
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        override = agent._override_instructions.get()
+        instructions = override.value if override is not None else agent._instructions
+        correct = "correct" in "\n".join(str(item) for item in instructions)
+        return MetricResult(
+            score=float(correct),
+            feedback="correct" if correct else f"Add correct guidance for {case.name}.",
+        )
+
+    return OptimizationTask(agent=agent, trainset=cases, metric=metric, valset=cases)
+
+
+def _candidate(text: str) -> CandidateMap:
+    return {"instructions": ComponentValue(name="instructions", text=text)}
+
+
+def test_registry_constructs_coding_agent_engine() -> None:
+    """Importing the engines package registers the built-in coding-agent engine."""
+
+    async def propose(context: ReflectionContext) -> CandidateMap:
+        return context.candidate
+
+    config = EngineConfig(engine="coding_agent", engine_config={"propose": propose})
+
+    assert isinstance(get_engine("coding_agent", config), CodingAgentEngine)
+
+
+@pytest.mark.asyncio
+async def test_coding_agent_engine_accepts_an_improving_proposal() -> None:
+    """A strictly better proposal is retained and receives the fair valset score."""
+    contexts: list[ReflectionContext] = []
+
+    async def propose(context: ReflectionContext) -> CandidateMap:
+        contexts.append(context)
+        return _candidate("correct")
+
+    config = EngineConfig(
+        engine="coding_agent",
+        max_metric_calls=9,
+        engine_config={
+            "propose": propose,
+            "minibatch_size": 3,
+            "max_proposals_per_run": 1,
+        },
+    )
+    budget = BudgetTracker(9)
+
+    result = await get_engine("coding_agent", config).run(_task(), config, budget)
+
+    assert result.best_candidate["instructions"].text == "correct"
+    assert result.best_score == 1.0
+    assert budget.spent == result.num_metric_calls == 9
+    assert [event.kind for event in result.history].count("accepted") == 1
+    assert contexts[0].minibatch_records
+    assert contexts[0].report.startswith("# Eval report")
+
+
+@pytest.mark.asyncio
+async def test_coding_agent_engine_rejects_equal_or_worse_proposals() -> None:
+    """Only a strict minibatch improvement can replace the current best candidate."""
+
+    async def propose(context: ReflectionContext) -> CandidateMap:
+        return _candidate("still wrong")
+
+    config = EngineConfig(
+        engine="coding_agent",
+        max_metric_calls=9,
+        engine_config={
+            "propose": propose,
+            "minibatch_size": 3,
+            "max_proposals_per_run": 1,
+        },
+    )
+
+    result = await get_engine("coding_agent", config).run(
+        _task(), config, BudgetTracker(9)
+    )
+
+    assert result.best_candidate["instructions"].text == "seed"
+    assert result.best_score == 0.0
+    assert any(event.kind == "rejected" for event in result.history)
+
+
+@pytest.mark.asyncio
+async def test_coding_agent_engine_stops_after_a_budget_overshoot() -> None:
+    """An oversized proposal evaluation keeps the already-confirmed seed candidate."""
+
+    async def propose(context: ReflectionContext) -> CandidateMap:
+        return _candidate("correct")
+
+    config = EngineConfig(
+        engine="coding_agent",
+        max_metric_calls=4,
+        engine_config={
+            "propose": propose,
+            "minibatch_size": 3,
+            "max_proposals_per_run": 1,
+        },
+    )
+    budget = BudgetTracker(4)
+
+    result = await get_engine("coding_agent", config).run(_task(), config, budget)
+
+    assert result.best_candidate["instructions"].text == "seed"
+    assert result.num_metric_calls == budget.spent == 3
+    assert any(event.kind == "budget_overshoot" for event in result.history)
+
+
+@pytest.mark.parametrize("propose", [None, "not callable", object()])
+def test_coding_agent_engine_requires_a_callable_proposer(propose: object) -> None:
+    """The proposal callback is a required engine-specific dependency."""
+    config = EngineConfig(engine="coding_agent", engine_config={"propose": propose})
+
+    with pytest.raises(TypeError, match=r"engine_config\['propose'\].*callable"):
+        CodingAgentEngine(config)
+
+
+@pytest.mark.asyncio
+async def test_coding_agent_engine_minibatches_are_deterministic_for_a_seed() -> None:
+    """Equal seeds produce the same sampled minibatch history and metric usage."""
+
+    async def propose(context: ReflectionContext) -> CandidateMap:
+        return _candidate("still wrong")
+
+    config = EngineConfig(
+        engine="coding_agent",
+        max_metric_calls=11,
+        seed=17,
+        engine_config={
+            "propose": propose,
+            "minibatch_size": 3,
+            "max_proposals_per_run": 1,
+        },
+    )
+    first = await get_engine("coding_agent", config).run(
+        _task(case_count=5), config, BudgetTracker(11)
+    )
+    second = await get_engine("coding_agent", config).run(
+        _task(case_count=5), config, BudgetTracker(11)
+    )
+
+    assert first.num_metric_calls == second.num_metric_calls == 11
+    assert [event.model_dump() for event in first.history] == [
+        event.model_dump() for event in second.history
+    ]


### PR DESCRIPTION
## Summary
Stack position **3/5** — implements pydanticaigepa-spec-t9q.

`CodingAgentEngine` (`engine="coding_agent"`) — the meta-harness analog. The library owns deterministic minibatch sampling, evaluation, and monotonic candidate selection; a caller-supplied async `propose(ReflectionContext)` callback (a coding agent) owns reflection. This makes the spec-973 external-reflection loop runnable in-process as a first-class engine. Dual engine-slice + shared budget tracking; the fair-comparison valset eval is charged or explicitly flagged.

## Contract
Proposer is text-bound to the existing component catalog (instructions, tool/output descriptions) — it cannot add/remove/rename tools. That boundary keeps composed-pipeline comparison apples-to-apples and is now documented in the spec.

## Testing
- `uv run pytest tests/engines -q` (18 tests): accept/reject/overshoot/determinism/proposer-validation
- ruff clean; pyright 0 errors







#### PR Dependency Tree


* **PR #21** 👈
  * **PR #22**
    * **PR #23**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)