### PR TITLE
Add composition helpers and best_of_n reference engine

### DIFF
--- a/src/pydantic_ai_gepa/__init__.py
+++ b/src/pydantic_ai_gepa/__init__.py
@@ -18,6 +18,13 @@ from .inspection import (
 )
 from .exceptions import UsageBudgetExceeded
 from .runner import GepaOptimizationResult, optimize_agent
+from .compose import (
+    PipelineResult,
+    optimize_best_of,
+    optimize_parallel,
+    optimize_sequential,
+    optimize_vote,
+)
 from .engines import (
     BudgetExhausted,
     BudgetTracker,
@@ -60,6 +67,11 @@ from .types import (
 
 __all__ = [
     "optimize_agent",
+    "optimize_parallel",
+    "optimize_best_of",
+    "optimize_sequential",
+    "optimize_vote",
+    "PipelineResult",
     "GepaOptimizationResult",
     "Adapter",
     "AgentAdapter",

--- a/src/pydantic_ai_gepa/compose.py
+++ b/src/pydantic_ai_gepa/compose.py
@@ -1,0 +1,208 @@
+"""Helpers for composing optimization engines under one shared budget."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from .engines import (
+    BudgetTracker,
+    EngineConfig,
+    EngineEvent,
+    EngineResult,
+    OptimizationTask,
+    get_engine,
+)
+from .gepa_graph.models import CandidateMap
+
+
+class PipelineResult(BaseModel):
+    """Results of a composed engine run and its fairly selected winner."""
+
+    results: list[EngineResult]
+    best: EngineResult
+    best_index: int
+    fair_scores: list[float]
+    total_metric_calls: int
+
+    model_config = ConfigDict(frozen=True)
+
+
+class _SeededTask:
+    """Delegate a task while supplying a fixed seed candidate to an engine."""
+
+    def __init__(self, task: OptimizationTask, seed: CandidateMap) -> None:
+        self._task = task
+        self._seed = seed
+
+    async def seed_candidate(self) -> CandidateMap:
+        """Return the candidate adopted by the preceding pipeline stage."""
+        return self._seed
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward all non-seed task operations to the wrapped task."""
+        return getattr(self._task, name)
+
+
+async def optimize_parallel(
+    task: OptimizationTask,
+    configs: Sequence[EngineConfig],
+    *,
+    max_metric_calls: int,
+) -> list[EngineResult]:
+    """Run configured engines concurrently against one shared metric budget.
+
+    Failures propagate from :func:`asyncio.gather`: a failed engine makes the
+    pipeline fail loudly instead of silently returning a partial comparison.
+    """
+    budget = BudgetTracker(max_metric_calls)
+    return await _run_parallel(task, configs, budget)
+
+
+async def optimize_best_of(
+    task: OptimizationTask,
+    configs: Sequence[EngineConfig],
+    *,
+    max_metric_calls: int,
+) -> PipelineResult:
+    """Run engines in parallel and choose the highest fair valset score.
+
+    Fair evaluations are intentionally uncharged, matching coding-agent final
+    evaluation semantics and ensuring engines are compared on the same valset.
+    """
+    budget = BudgetTracker(max_metric_calls)
+    results = await _run_parallel(task, configs, budget)
+    best_index, fair_scores = await _select_fair_winner(task, results)
+    return _pipeline_result(results, best_index, fair_scores, budget)
+
+
+async def optimize_sequential(
+    task: OptimizationTask,
+    configs: Sequence[EngineConfig],
+    *,
+    max_metric_calls: int,
+) -> PipelineResult:
+    """Run engines in order, seeding each from the last non-regressing result.
+
+    Each stage and its incoming seed are evaluated on the valset without
+    charging the optimization budget.  A lower-scoring stage is not adopted as
+    the next seed, which keeps the chain monotonic under the shared evaluator.
+    """
+    if not configs:
+        raise ValueError("At least one engine config is required.")
+
+    budget = BudgetTracker(max_metric_calls)
+    seed = await task.seed_candidate()
+    seed_score = (await task.evaluate(seed, budget=None)).score
+    adopted_result = EngineResult(
+        engine="seed",
+        best_candidate=seed,
+        best_score=seed_score,
+        num_metric_calls=0,
+        history=[EngineEvent(kind="seed", data={"fair_score": seed_score})],
+    )
+    adopted_index = -1
+    results: list[EngineResult] = []
+    fair_scores: list[float] = []
+
+    for index, config in enumerate(configs):
+        stage_task: OptimizationTask
+        if index == 0:
+            stage_task = task
+        else:
+            stage_task = cast(OptimizationTask, _SeededTask(task, seed))
+        result = await get_engine(config.engine, config).run(stage_task, config, budget)
+        results.append(result)
+        fair_score = (await task.evaluate(result.best_candidate, budget=None)).score
+        fair_scores.append(fair_score)
+        if fair_score >= seed_score:
+            seed = result.best_candidate
+            seed_score = fair_score
+            adopted_result = result
+            adopted_index = index
+
+    return PipelineResult(
+        results=results,
+        best=adopted_result,
+        best_index=adopted_index,
+        fair_scores=fair_scores,
+        total_metric_calls=budget.spent,
+    )
+
+
+async def optimize_vote(
+    task: OptimizationTask,
+    configs: Sequence[EngineConfig],
+    *,
+    max_metric_calls: int,
+) -> PipelineResult:
+    """Run engines in parallel and select a winner by an uncharged valset vote.
+
+    This shares the fair-selection implementation with ``optimize_best_of``;
+    the APIs differ in intent, with this helper emphasizing the re-evaluation
+    vote as the selection mechanism.
+    """
+    budget = BudgetTracker(max_metric_calls)
+    results = await _run_parallel(task, configs, budget)
+    best_index, fair_scores = await _select_fair_winner(task, results)
+    return _pipeline_result(results, best_index, fair_scores, budget)
+
+
+async def _run_parallel(
+    task: OptimizationTask,
+    configs: Sequence[EngineConfig],
+    budget: BudgetTracker,
+) -> list[EngineResult]:
+    """Construct and concurrently run engines in configuration order."""
+    engines = [get_engine(config.engine, config) for config in configs]
+    return list(
+        await asyncio.gather(
+            *(
+                engine.run(task, config, budget)
+                for engine, config in zip(engines, configs)
+            )
+        )
+    )
+
+
+async def _select_fair_winner(
+    task: OptimizationTask, results: Sequence[EngineResult]
+) -> tuple[int, list[float]]:
+    """Return the earliest result with the highest uncharged full-valset score."""
+    if not results:
+        raise ValueError("At least one engine result is required.")
+    fair_scores = [
+        (await task.evaluate(result.best_candidate, budget=None)).score
+        for result in results
+    ]
+    return max(
+        range(len(fair_scores)), key=lambda index: fair_scores[index]
+    ), fair_scores
+
+
+def _pipeline_result(
+    results: list[EngineResult],
+    best_index: int,
+    fair_scores: list[float],
+    budget: BudgetTracker,
+) -> PipelineResult:
+    """Build a public result without exposing the mutable budget tracker."""
+    return PipelineResult(
+        results=results,
+        best=results[best_index],
+        best_index=best_index,
+        fair_scores=fair_scores,
+        total_metric_calls=budget.spent,
+    )
+
+
+__all__ = [
+    "PipelineResult",
+    "optimize_best_of",
+    "optimize_parallel",
+    "optimize_sequential",
+    "optimize_vote",
+]

--- a/src/pydantic_ai_gepa/engines/__init__.py
+++ b/src/pydantic_ai_gepa/engines/__init__.py
@@ -19,10 +19,12 @@ from .registry import (
 )
 from .gepa_engine import GepaEngine
 from .coding_agent_engine import CodingAgentEngine, Proposer, ReflectionContext
+from .best_of_n import BestOfNEngine
 
 __all__ = [
     "BudgetExhausted",
     "BudgetTracker",
+    "BestOfNEngine",
     "CandidateEvaluation",
     "CodingAgentEngine",
     "EngineConfig",

--- a/src/pydantic_ai_gepa/engines/best_of_n.py
+++ b/src/pydantic_ai_gepa/engines/best_of_n.py
@@ -1,0 +1,112 @@
+"""A small reference engine that selects the best of sampled candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+from ..gepa_graph.models import CandidateMap
+from .base import (
+    BudgetExhausted,
+    BudgetTracker,
+    EngineConfig,
+    EngineEvent,
+    EngineResult,
+    OptimizationTask,
+)
+from .registry import register_engine
+
+Proposer = Callable[[CandidateMap], Awaitable[CandidateMap]]
+
+
+class BestOfNEngine:
+    """Sample variants of the seed and keep the highest-scoring candidate.
+
+    ``engine_config['propose']`` is a required async callback accepting the
+    seed :class:`CandidateMap` and returning one derived candidate.  The seed
+    itself is always evaluated as candidate zero, so a completed run cannot
+    select a candidate worse than its evaluated seed.
+    """
+
+    name = "best_of_n"
+
+    def __init__(self, config: EngineConfig) -> None:
+        """Read the required proposal callback and the variant count."""
+        propose = config.engine_config.get("propose")
+        if not callable(propose):
+            raise TypeError(
+                "engine_config['propose'] must be a callable async callback that "
+                "accepts a CandidateMap seed and returns a CandidateMap."
+            )
+        n = config.engine_config.get("n", 4)
+        if not isinstance(n, int) or isinstance(n, bool) or n < 1:
+            raise ValueError("engine_config['n'] must be a positive integer.")
+
+        self._propose = cast(Proposer, propose)
+        self._n = n
+
+    async def run(
+        self,
+        task: OptimizationTask,
+        config: EngineConfig,
+        budget: BudgetTracker,
+    ) -> EngineResult:
+        """Evaluate the seed and ``n`` derived candidates under ``budget``."""
+        del config  # This engine has no shared options beyond its constructor config.
+        budget.check()
+        starting_spend = budget.spent
+        seed = await task.seed_candidate()
+        candidates = [seed]
+        for _ in range(self._n):
+            candidates.append(await self._propose(seed))
+
+        best_candidate = seed
+        best_score = 0.0
+        scores: list[float | None] = []
+        history: list[EngineEvent] = []
+        for index, candidate in enumerate(candidates):
+            try:
+                evaluation = await task.evaluate(candidate, budget=budget)
+            except BudgetExhausted:
+                scores.append(None)
+                history.append(
+                    EngineEvent(
+                        kind="budget_overshoot",
+                        message="Candidate evaluation exceeded the shared metric-call budget.",
+                        data={
+                            "candidate_index": index,
+                            "budget_remaining": budget.remaining,
+                        },
+                    )
+                )
+                break
+
+            scores.append(evaluation.score)
+            if index == 0 or evaluation.score > best_score:
+                best_candidate = candidate
+                best_score = evaluation.score
+
+        history.append(
+            EngineEvent(
+                kind="summary",
+                data={
+                    "num_variants": self._n,
+                    "candidate_scores": scores
+                    + [None] * (len(candidates) - len(scores)),
+                    "evaluated_candidates": len(scores) - scores.count(None),
+                },
+            )
+        )
+        return EngineResult(
+            engine=self.name,
+            best_candidate=best_candidate,
+            best_score=best_score,
+            num_metric_calls=budget.spent - starting_spend,
+            history=history,
+        )
+
+
+register_engine(BestOfNEngine.name, BestOfNEngine, replace=True)
+
+
+__all__ = ["BestOfNEngine", "Proposer"]

--- a/tests/engines/test_best_of_n.py
+++ b/tests/engines/test_best_of_n.py
@@ -1,0 +1,116 @@
+"""Coverage for the reference best-of-N optimization engine."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+from pydantic_evals import Case
+
+from pydantic_ai_gepa.engines import (
+    BestOfNEngine,
+    BudgetTracker,
+    EngineConfig,
+    OptimizationTask,
+    get_engine,
+)
+from pydantic_ai_gepa.gepa_graph.models import CandidateMap, ComponentValue
+from pydantic_ai_gepa.types import MetricResult, RolloutOutput
+
+
+def _candidate(text: str) -> CandidateMap:
+    return {"instructions": ComponentValue(name="instructions", text=text)}
+
+
+def _task(*, case_count: int = 1, instructions: str = "seed") -> OptimizationTask:
+    agent = Agent(TestModel(custom_output_text="response"), instructions=instructions)
+    cases = [
+        Case(name=f"case-{index}", inputs="input", expected_output="response")
+        for index in range(case_count)
+    ]
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        override = agent._override_instructions.get()
+        active = override.value if override is not None else agent._instructions
+        return MetricResult(score=float("correct" in str(active)))
+
+    return OptimizationTask(agent=agent, trainset=cases, metric=metric, valset=cases)
+
+
+def test_registry_constructs_best_of_n_engine() -> None:
+    async def propose(seed: CandidateMap) -> CandidateMap:
+        return seed
+
+    config = EngineConfig(engine="best_of_n", engine_config={"propose": propose})
+
+    assert isinstance(get_engine("best_of_n", config), BestOfNEngine)
+
+
+@pytest.mark.asyncio
+async def test_best_of_n_selects_the_highest_scoring_variant() -> None:
+    variants = iter([_candidate("still wrong"), _candidate("correct")])
+
+    async def propose(seed: CandidateMap) -> CandidateMap:
+        return next(variants)
+
+    config = EngineConfig(
+        engine="best_of_n",
+        engine_config={"n": 2, "propose": propose},
+    )
+    budget = BudgetTracker(3)
+
+    result = await get_engine("best_of_n", config).run(_task(), config, budget)
+
+    assert result.best_candidate["instructions"].text == "correct"
+    assert result.best_score == 1.0
+    assert result.num_metric_calls == budget.spent == 3
+    assert result.history[-1].data["candidate_scores"] == [0.0, 0.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_best_of_n_never_selects_a_candidate_worse_than_the_seed() -> None:
+    async def propose(seed: CandidateMap) -> CandidateMap:
+        return _candidate("wrong")
+
+    config = EngineConfig(
+        engine="best_of_n",
+        engine_config={"n": 2, "propose": propose},
+    )
+
+    result = await get_engine("best_of_n", config).run(
+        _task(instructions="correct seed"), config, BudgetTracker(3)
+    )
+
+    assert result.best_candidate["instructions"].text == "correct seed"
+    assert result.best_score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_best_of_n_stops_evaluating_on_budget_overshoot() -> None:
+    async def propose(seed: CandidateMap) -> CandidateMap:
+        return _candidate("correct")
+
+    config = EngineConfig(
+        engine="best_of_n",
+        engine_config={"n": 2, "propose": propose},
+    )
+    budget = BudgetTracker(3)
+
+    result = await get_engine("best_of_n", config).run(
+        _task(case_count=2), config, budget
+    )
+
+    assert result.best_candidate["instructions"].text == "seed"
+    assert result.num_metric_calls == budget.spent == 2
+    assert [event.kind for event in result.history].count("budget_overshoot") == 1
+    assert result.history[-1].data["candidate_scores"] == [0.0, None, None]
+
+
+@pytest.mark.parametrize("propose", [None, "not callable", object()])
+def test_best_of_n_requires_a_callable_proposer(propose: object) -> None:
+    config = EngineConfig(engine="best_of_n", engine_config={"propose": propose})
+
+    with pytest.raises(TypeError, match=r"engine_config\['propose'\].*callable"):
+        BestOfNEngine(config)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,156 @@
+"""Coverage for public optimization-engine composition helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+from pydantic_evals import Case
+
+from pydantic_ai_gepa.compose import (
+    optimize_best_of,
+    optimize_parallel,
+    optimize_sequential,
+    optimize_vote,
+)
+from pydantic_ai_gepa.engines import (
+    BudgetTracker,
+    EngineConfig,
+    EngineResult,
+    OptimizationTask,
+    register_engine,
+    unregister_engine,
+)
+from pydantic_ai_gepa.gepa_graph.models import CandidateMap, ComponentValue
+from pydantic_ai_gepa.types import MetricResult, RolloutOutput
+
+_ENGINE_NAME = "compose_test_engine"
+
+
+def _candidate(text: str) -> CandidateMap:
+    return {"instructions": ComponentValue(name="instructions", text=text)}
+
+
+def _task() -> OptimizationTask:
+    agent = Agent(TestModel(custom_output_text="response"), instructions="seed")
+    cases = [Case(name="case", inputs="input", expected_output="response")]
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        override = agent._override_instructions.get()
+        active = override.value if override is not None else agent._instructions
+        return MetricResult(score=float("correct" in str(active)))
+
+    return OptimizationTask(agent=agent, trainset=cases, metric=metric, valset=cases)
+
+
+class _FakeEngine:
+    name = _ENGINE_NAME
+
+    def __init__(self, config: EngineConfig) -> None:
+        self._config = config
+
+    async def run(
+        self,
+        task: OptimizationTask,
+        config: EngineConfig,
+        budget: BudgetTracker,
+    ) -> EngineResult:
+        options = config.engine_config
+        seen = options.get("seen_seeds")
+        if isinstance(seen, list):
+            seen.append((await task.seed_candidate())["instructions"].text)
+        spend = options.get("spend", 0)
+        budget.spend(spend)
+        return EngineResult(
+            engine=self.name,
+            best_candidate=options["candidate"],
+            best_score=options.get("reported_score", 0.0),
+            num_metric_calls=spend,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _registered_fake_engine() -> None:
+    unregister_engine(_ENGINE_NAME)
+    register_engine(_ENGINE_NAME, _FakeEngine, replace=True)
+    yield
+    unregister_engine(_ENGINE_NAME)
+
+
+def _config(
+    candidate: CandidateMap,
+    *,
+    reported_score: float = 0.0,
+    spend: int = 0,
+    seen_seeds: list[str] | None = None,
+) -> EngineConfig:
+    options: dict[str, Any] = {
+        "candidate": candidate,
+        "reported_score": reported_score,
+        "spend": spend,
+    }
+    if seen_seeds is not None:
+        options["seen_seeds"] = seen_seeds
+    return EngineConfig(engine=_ENGINE_NAME, engine_config=options)
+
+
+@pytest.mark.asyncio
+async def test_optimize_parallel_preserves_order_and_shares_its_budget() -> None:
+    first = _config(_candidate("first"), spend=1)
+    second = _config(_candidate("second"), spend=2)
+
+    results = await optimize_parallel(_task(), [first, second], max_metric_calls=3)
+
+    assert [result.best_candidate["instructions"].text for result in results] == [
+        "first",
+        "second",
+    ]
+    assert sum(result.num_metric_calls for result in results) == 3
+
+
+@pytest.mark.asyncio
+async def test_optimize_best_of_uses_fair_valset_scores_not_reported_scores() -> None:
+    low_actual = _config(_candidate("wrong"), reported_score=99.0)
+    high_actual = _config(_candidate("correct"), reported_score=-1.0)
+
+    result = await optimize_best_of(
+        _task(), [low_actual, high_actual], max_metric_calls=2
+    )
+
+    assert result.best_index == 1
+    assert result.best.best_candidate == result.results[1].best_candidate
+    assert result.fair_scores == [0.0, 1.0]
+    assert [item.best_score for item in result.results] == [99.0, -1.0]
+    assert result.total_metric_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_optimize_sequential_chains_seeds_and_rejects_regressions() -> None:
+    seen_seeds: list[str] = []
+    configs = [
+        _config(_candidate("correct first"), seen_seeds=seen_seeds),
+        _config(_candidate("wrong second"), seen_seeds=seen_seeds),
+        _config(_candidate("correct third"), seen_seeds=seen_seeds),
+    ]
+
+    result = await optimize_sequential(_task(), configs, max_metric_calls=2)
+
+    assert seen_seeds == ["seed", "correct first", "correct first"]
+    assert result.fair_scores == [1.0, 0.0, 1.0]
+    assert result.best_index == 2
+    assert result.best.best_candidate == result.results[2].best_candidate
+
+
+@pytest.mark.asyncio
+async def test_optimize_vote_selects_the_highest_valset_score() -> None:
+    result = await optimize_vote(
+        _task(),
+        [_config(_candidate("wrong")), _config(_candidate("correct"))],
+        max_metric_calls=2,
+    )
+
+    assert result.best_index == 1
+    assert result.best.best_candidate["instructions"].text == "correct"
+    assert result.fair_scores == [0.0, 1.0]


### PR DESCRIPTION
## Summary
Stack position **4/5** — implements pydanticaigepa-spec-t9q.

`compose.py` — the omni composition primitives over registered engines under one shared metric-call budget: `optimize_parallel`, `optimize_best_of`/`optimize_vote` (winner picked by fair, uncharged full-valset re-eval, never engine self-reports), and `optimize_sequential` (monotonic seed chaining via a seed-override task proxy — a regressing stage cannot poison the next). Plus `BestOfNEngine`, a from-scratch reference engine (never worse than its evaluated seed).

## Contract
Cross-engine comparison is only valid through the shared `OptimizationTask.evaluate` on the same valset; helpers that pick a winner re-evaluate this way. `optimize_adaptive_sequential` intentionally deferred (needs plateau detection).

## Testing
- `uv run pytest tests/engines tests/test_compose.py -q` (29 tests) incl. fair-selection-over-self-report and sequential regression-rejection
- Full suite 292 + 134 CLI passed; ruff clean; pyright 0 errors










#### PR Dependency Tree


* **PR #22** 👈
  * **PR #23**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)