### PR TITLE
Managed-run event bus: gepa next / gepa ack (stack 2/5)

### DIFF
--- a/src/pydantic_ai_gepa/cli/__init__.py
+++ b/src/pydantic_ai_gepa/cli/__init__.py
@@ -12,6 +12,7 @@ import typer
 from . import apply as apply_cmd
 from . import components as components_cmd
 from . import eval as eval_cmd
+from . import events as events_cmd
 from . import init as init_cmd
 from . import journal as journal_cmd
 from . import pareto as pareto_cmd
@@ -74,6 +75,8 @@ app.command(
 app.command(name="pareto", help="Show Pareto front or full history (json or tsv).")(
     pareto_cmd.pareto
 )
+app.command(name="next")(events_cmd.next_command)
+app.command(name="ack")(events_cmd.ack_command)
 app.add_typer(
     run_cmd.app,
     name="run",

--- a/src/pydantic_ai_gepa/cli/events.py
+++ b/src/pydantic_ai_gepa/cli/events.py
@@ -1,0 +1,615 @@
+"""Managed-run event bus: one JSON file per event, `gepa next` / `gepa ack`.
+
+Implements pydanticaigepa-spec-fmc. Producers create one file per event under
+``runs/<run_id>/events/`` with exclusive create — the filename *is* the event
+id (``<zero-padded ms timestamp>-<producer id>-<per-producer seq>``), so
+uniqueness holds by construction with no shared read-modify-write
+(pydanticaigepa-dec-f1s). The consumer cursor lives in
+``runs/<run_id>/cursor.json`` and holds the highest acked event id; delivery
+order is lexicographic id order.
+
+Every ``gepa next`` first runs a reaper pass (pydanticaigepa-dec-pm3): given a
+lane-scan result it synthesizes ``lane_stalled`` / ``selection_due`` events
+idempotently keyed by (lane, lease epoch). Lane-state scanning lands with the
+lane lifecycle (pydanticaigepa-task-xcb); :func:`scan_lanes` is the stubbed
+seam the real scanner will replace.
+
+CLI exit codes (also documented in each verb's help text): 0 event delivered
+or ack accepted, 1 run resolution/usage error, 3 no pending events, 4
+``--wait`` timeout elapsed, 5 ack rejected (non-oldest unacked event).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import typer
+
+from .layout import latest_run_id, run_dir
+from .runs import utc_now_iso
+
+EventType = Literal[
+    "lane_ready",
+    "verdict",
+    "selection_due",
+    "merge_opportunity",
+    "lane_stalled",
+    "budget_low",
+    "run_done",
+]
+
+EVENT_TYPES: tuple[str, ...] = (
+    "lane_ready",
+    "verdict",
+    "selection_due",
+    "merge_opportunity",
+    "lane_stalled",
+    "budget_low",
+    "run_done",
+)
+
+# Payload key sets per the spec-fmc Interface block. Event payloads carry
+# paths and scalars only — trace or diff content never goes inline.
+EVENT_PAYLOAD_FIELDS: dict[str, frozenset[str]] = {
+    "lane_ready": frozenset({"packet_path", "worktree_path"}),
+    "verdict": frozenset({"verdict", "delta", "comparison_path"}),
+    "selection_due": frozenset({"iteration", "resolved_lanes", "straggler_lanes"}),
+    "merge_opportunity": frozenset(
+        {"lane_a", "lane_b", "branch_a", "branch_b", "diff_stat_path"}
+    ),
+    "lane_stalled": frozenset({"reason", "lease_epoch"}),
+    "budget_low": frozenset({"remaining_evals"}),
+    "run_done": frozenset({"final_report_path"}),
+}
+
+# Run-scoped events carry ``lane=None``; everything else is lane-scoped.
+RUN_SCOPED_TYPES: frozenset[str] = frozenset(
+    {"selection_due", "merge_opportunity", "budget_low", "run_done"}
+)
+
+EVENTS_DIRNAME = "events"
+CURSOR_FILENAME = "cursor.json"
+
+REAPER_PRODUCER_ID = "reaper"
+
+# `gepa next` / `gepa ack` exit codes — distinct per spec-fmc.
+EXIT_DELIVERED = 0
+EXIT_NONE_PENDING = 3
+EXIT_TIMEOUT = 4
+EXIT_ACK_REJECTED = 5
+
+_TIMESTAMP_WIDTH = 13  # zero-padded epoch milliseconds
+_SEQ_WIDTH = 6
+_PRODUCER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_EVENT_ID_RE = re.compile(
+    rf"^(\d{{{_TIMESTAMP_WIDTH}}})-([A-Za-z0-9][A-Za-z0-9._-]*)-(\d{{{_SEQ_WIDTH}}})$"
+)
+
+# Per-process (run dir, producer id) -> next sequence number, guarded by a lock
+# so in-process producers (threads) allocate distinct ids without rescanning.
+_seq_lock = threading.Lock()
+_seq_counters: dict[tuple[Path, str], int] = {}
+
+
+class EventError(ValueError):
+    """Raised when an event draft or producer id fails validation."""
+
+
+class AckRejected(RuntimeError):
+    """Raised when acking anything other than the oldest unacked event."""
+
+
+# ----------------------------- event records ----------------------------
+
+
+def _validate_scalar_or_scalar_list(value: Any, *, field_name: str) -> None:
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _validate_scalar_or_scalar_list(item, field_name=field_name)
+        return
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return
+    raise EventError(
+        f"Payload field {field_name!r} must be a path or scalar (str, int, "
+        f"float, bool, null) or a list of those; got {type(value).__name__}. "
+        "Inline content (nested objects, traces, diffs) is never allowed."
+    )
+
+
+def _validate_draft(type: str, lane: str | None, payload: dict[str, Any]) -> None:
+    if type not in EVENT_PAYLOAD_FIELDS:
+        raise EventError(
+            f"Unknown event type {type!r}; expected one of: {', '.join(EVENT_TYPES)}."
+        )
+    expected = EVENT_PAYLOAD_FIELDS[type]
+    missing = expected - payload.keys()
+    extra = payload.keys() - expected
+    if missing:
+        raise EventError(
+            f"Event type {type!r} is missing payload fields: "
+            f"{', '.join(sorted(missing))}."
+        )
+    if extra:
+        raise EventError(
+            f"Event type {type!r} got unknown payload fields: "
+            f"{', '.join(sorted(extra))} (payload schema is fixed by spec)."
+        )
+    for key, value in payload.items():
+        _validate_scalar_or_scalar_list(value, field_name=key)
+    if type in RUN_SCOPED_TYPES:
+        if lane is not None:
+            raise EventError(f"Run-scoped event {type!r} must carry lane=None.")
+    elif lane is None:
+        raise EventError(f"Lane-scoped event {type!r} requires a lane id.")
+
+
+@dataclass(frozen=True)
+class EventDraft:
+    """Producer-supplied event content; ``emit`` assigns the id and timestamp."""
+
+    type: EventType
+    lane: str | None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_draft(self.type, self.lane, self.payload)
+
+
+@dataclass(frozen=True)
+class Event:
+    """A persisted event record (one JSON file under ``runs/<run_id>/events/``)."""
+
+    id: str
+    type: EventType
+    ts: str
+    lane: str | None
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "ts": self.ts,
+            "lane": self.lane,
+            "payload": dict(self.payload),
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> Event:
+        return Event(
+            id=str(data["id"]),
+            type=str(data["type"]),  # type: ignore[arg-type]
+            ts=str(data["ts"]),
+            lane=data.get("lane"),
+            payload=dict(data.get("payload", {})),
+        )
+
+
+# ----------------------------- storage paths ----------------------------
+
+
+def events_dir(run_id: str, root: Path | None = None) -> Path:
+    return run_dir(run_id, root) / EVENTS_DIRNAME
+
+
+def cursor_path(run_id: str, root: Path | None = None) -> Path:
+    return run_dir(run_id, root) / CURSOR_FILENAME
+
+
+def _read_event(path: Path) -> Event:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data.setdefault("id", path.name)
+    return Event.from_dict(data)
+
+
+def list_events(run_id: str, root: Path | None = None) -> list[Event]:
+    """Return every event on the run's bus in lexicographic id (delivery) order."""
+    base = events_dir(run_id, root)
+    if not base.is_dir():
+        return []
+    events = [
+        _read_event(path) for path in sorted(base.iterdir(), key=lambda p: p.name)
+    ]
+    events.sort(key=lambda event: event.id)
+    return events
+
+
+# ----------------------------- cursor -----------------------------------
+
+
+def load_cursor(run_id: str, root: Path | None = None) -> str | None:
+    """Return the highest acked event id, or ``None`` when nothing was acked."""
+    path = cursor_path(run_id, root)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    acked = data.get("acked_id")
+    return str(acked) if acked else None
+
+
+def advance_cursor(run_id: str, event_id: str, root: Path | None = None) -> None:
+    """Persist ``event_id`` as the highest acked id (atomic tmp-file replace)."""
+    path = cursor_path(run_id, root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump({"acked_id": event_id}, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        os.unlink(tmp_name)
+        raise
+
+
+# ----------------------------- producer API -----------------------------
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _scan_next_seq(events_path: Path, producer_id: str) -> int:
+    """Derive the next per-producer seq from existing files (fresh processes)."""
+    next_seq = 0
+    if not events_path.is_dir():
+        return next_seq
+    infix = f"-{producer_id}-"
+    for path in events_path.iterdir():
+        match = _EVENT_ID_RE.match(path.name)
+        if match and match.group(2) == producer_id:
+            next_seq = max(next_seq, int(match.group(3)) + 1)
+        elif infix in path.name:
+            # Defensive: ignore unparseable ids; seq allocation only trusts
+            # well-formed producer ids.
+            continue
+    return next_seq
+
+
+def _next_seq(events_path: Path, producer_id: str) -> int:
+    key = (events_path, producer_id)
+    with _seq_lock:
+        if key not in _seq_counters:
+            _seq_counters[key] = _scan_next_seq(events_path, producer_id)
+        seq = _seq_counters[key]
+        _seq_counters[key] = seq + 1
+    return seq
+
+
+def _release_seq(events_path: Path, producer_id: str, seq: int) -> None:
+    """Return an unused seq to the pool after a create collision or write error."""
+    key = (events_path, producer_id)
+    with _seq_lock:
+        if _seq_counters.get(key, 0) == seq + 1:
+            _seq_counters[key] = seq
+
+
+def _bump_seq_past(events_path: Path, producer_id: str, seq: int) -> None:
+    key = (events_path, producer_id)
+    with _seq_lock:
+        if _seq_counters.get(key, 0) <= seq:
+            _seq_counters[key] = seq + 1
+
+
+def emit(
+    run_id: str,
+    producer_id: str,
+    draft: EventDraft,
+    *,
+    root: Path | None = None,
+) -> str:
+    """Create the event file with exclusive create and return the event id.
+
+    Uniqueness holds by construction: the filename embeds the zero-padded ms
+    timestamp, the producer id, and a per-producer sequence number; a create
+    collision (same ms) retries with the seq bumped. Payload validation happens
+    at ``EventDraft`` construction, so invalid payloads are rejected before any
+    file is touched.
+    """
+    if not _PRODUCER_ID_RE.match(producer_id):
+        raise EventError(
+            f"Invalid producer id {producer_id!r}; expected "
+            f"{_PRODUCER_ID_RE.pattern!r} (filename-safe)."
+        )
+    path = events_dir(run_id, root)
+    path.mkdir(parents=True, exist_ok=True)
+    ts_ms = f"{_now_ms():0{_TIMESTAMP_WIDTH}d}"
+    body = {
+        "type": draft.type,
+        "ts": utc_now_iso(),
+        "lane": draft.lane,
+        "payload": dict(draft.payload),
+    }
+    while True:
+        seq = _next_seq(path, producer_id)
+        event_id = f"{ts_ms}-{producer_id}-{seq:0{_SEQ_WIDTH}d}"
+        file_path = path / event_id
+        record = {"id": event_id, **body}
+        try:
+            with file_path.open("x", encoding="utf-8") as handle:
+                json.dump(record, handle, indent=2)
+                handle.write("\n")
+            return event_id
+        except FileExistsError:
+            # Timestamp collision with another emit: retry with the seq bumped.
+            _bump_seq_past(path, producer_id, seq)
+        except OSError:
+            _release_seq(path, producer_id, seq)
+            raise
+
+
+# ----------------------------- consumer API -----------------------------
+
+
+def next_event(run_id: str, root: Path | None = None) -> Event | None:
+    """Return the oldest unacked event (id > cursor), or ``None`` if none."""
+    cursor = load_cursor(run_id, root)
+    for event in list_events(run_id, root):
+        if cursor is None or event.id > cursor:
+            return event
+    return None
+
+
+def ack(run_id: str, event_id: str, root: Path | None = None) -> bool:
+    """Ack ``event_id``. Returns True when the cursor advanced, False on a no-op.
+
+    Acking is idempotent: an id at or below the persisted cursor is a no-op
+    success. Acking anything other than the oldest unacked event raises
+    :class:`AckRejected` (the CLI maps it to exit code 5).
+    """
+    cursor = load_cursor(run_id, root)
+    if cursor is not None and event_id <= cursor:
+        return False
+    pending = next_event(run_id, root)
+    if pending is None:
+        raise AckRejected(
+            f"No pending event to ack (cursor already at {cursor!r}); "
+            f"refusing to ack {event_id!r}."
+        )
+    if event_id != pending.id:
+        raise AckRejected(
+            f"Refusing to ack {event_id!r}: the oldest unacked event is "
+            f"{pending.id!r}. Events must be acked in delivery order."
+        )
+    advance_cursor(run_id, event_id, root)
+    return True
+
+
+# ----------------------------- reaper (lazy) ----------------------------
+
+
+@dataclass(frozen=True)
+class LaneScanResult:
+    """One lane's liveness scan row (produced by the lane-state scanner).
+
+    ``stalled_reason`` is set when the reaper should synthesize a
+    ``lane_stalled`` event: the eval pid is dead, the heartbeat is stale, or
+    the reflection lease expired. ``lease_epoch`` is the idempotency key — a
+    lane that stalls again later reports under a fresh epoch.
+    """
+
+    lane: str
+    lease_epoch: int
+    stalled_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectionDueSignal:
+    """Run-scoped straggler-timeout finding from a scan pass."""
+
+    iteration: int
+    resolved_lanes: tuple[str, ...] = ()
+    straggler_lanes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LaneScan:
+    """Aggregate scan result handed to the reaper pass."""
+
+    lanes: tuple[LaneScanResult, ...] = ()
+    selection_due: SelectionDueSignal | None = None
+
+
+def scan_lanes(run_id: str, root: Path | None = None) -> LaneScan:
+    """Scan lane leases, heartbeat freshness, and recorded pids.
+
+    Stubbed seam: lane state lands with the lane lifecycle
+    (pydanticaigepa-task-xcb), so until then every scan reports no lanes and
+    no selection pressure. The reaper pass consumes this result object; tests
+    and slice 3 inject real scans the same way.
+    """
+    return LaneScan()
+
+
+def run_reaper_pass(
+    run_id: str,
+    scan: LaneScan | None = None,
+    *,
+    root: Path | None = None,
+    producer_id: str = REAPER_PRODUCER_ID,
+) -> list[str]:
+    """Synthesize ``lane_stalled`` / ``selection_due`` events from a scan result.
+
+    Idempotent: before emitting, existing event files are checked for an event
+    with the same key — ``(lane_stalled, lane, payload.lease_epoch)`` or
+    ``(selection_due, lane=None, payload.iteration)`` — so no matter how many
+    passes run, a (lane, lease epoch) pair never produces a duplicate.
+    Returns the ids of events emitted by this pass.
+    """
+    if scan is None:
+        scan = scan_lanes(run_id, root)
+    existing = list_events(run_id, root)
+    emitted: list[str] = []
+    for lane in scan.lanes:
+        if lane.stalled_reason is None:
+            continue
+        duplicate = any(
+            event.type == "lane_stalled"
+            and event.lane == lane.lane
+            and event.payload.get("lease_epoch") == lane.lease_epoch
+            for event in existing
+        )
+        if duplicate:
+            continue
+        emitted.append(
+            emit(
+                run_id,
+                producer_id,
+                EventDraft(
+                    type="lane_stalled",
+                    lane=lane.lane,
+                    payload={
+                        "reason": lane.stalled_reason,
+                        "lease_epoch": lane.lease_epoch,
+                    },
+                ),
+                root=root,
+            )
+        )
+    if scan.selection_due is not None:
+        signal = scan.selection_due
+        duplicate = any(
+            event.type == "selection_due"
+            and event.lane is None
+            and event.payload.get("iteration") == signal.iteration
+            for event in existing
+        )
+        if not duplicate:
+            emitted.append(
+                emit(
+                    run_id,
+                    producer_id,
+                    EventDraft(
+                        type="selection_due",
+                        lane=None,
+                        payload={
+                            "iteration": signal.iteration,
+                            "resolved_lanes": list(signal.resolved_lanes),
+                            "straggler_lanes": list(signal.straggler_lanes),
+                        },
+                    ),
+                    root=root,
+                )
+            )
+    return emitted
+
+
+# ----------------------------- CLI verbs --------------------------------
+
+_NEXT_HELP = """Deliver the oldest unacked event from the run's event bus.
+
+Runs a reaper pass first (scan lane leases/heartbeats/pids, synthesize
+lane_stalled / selection_due), then returns the oldest event past the
+persisted consumer cursor. Unacked events are redelivered verbatim, so
+crashing between `gepa next` and `gepa ack` loses nothing.
+
+Exit codes: 0 event delivered; 1 run resolution/usage error; 3 no pending
+events; 4 --wait timeout elapsed (distinct from "none pending").
+"""
+
+_ACK_HELP = """Ack an event, advancing the persisted consumer cursor past it.
+
+Events must be acked in delivery order: acking anything other than the
+oldest unacked event is rejected. Acking is idempotent — acking an id at
+or below the cursor is a no-op success.
+
+Exit codes: 0 cursor advanced or idempotent no-op; 1 run resolution/usage
+error; 5 ack rejected (not the oldest unacked event).
+"""
+
+
+def _resolve_run_id(run_id: str | None) -> str:
+    if run_id:
+        return run_id
+    latest = latest_run_id()
+    if latest is None:
+        typer.echo(
+            "No runs found under .gepa/runs/. Start one with `gepa run start`.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return latest
+
+
+def _emit_delivered(
+    event: Event,
+    *,
+    as_json: bool,
+    cursor_before: str | None,
+) -> None:
+    if as_json:
+        typer.echo(json.dumps(event.to_dict(), indent=2))
+        return
+    lane = event.lane if event.lane is not None else "-"
+    typer.echo(f"{event.id}\t{event.type}\tlane={lane}")
+    typer.echo(
+        f"unacked; ack with `gepa ack {event.id}` "
+        f"(cursor at {cursor_before or 'start'})"
+    )
+
+
+def next_command(
+    run_id: str | None = typer.Option(None, "--run-id", help="Defaults to latest run."),
+    wait: bool = typer.Option(
+        False, "--wait", help="Long-poll until an event arrives or --timeout elapses."
+    ),
+    timeout: float = typer.Option(
+        30.0, "--timeout", help="Seconds to long-poll with --wait."
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Print the full event record as JSON."
+    ),
+) -> None:
+    if timeout < 0:
+        typer.echo("--timeout must be non-negative.", err=True)
+        raise typer.Exit(code=1)
+    active_run = _resolve_run_id(run_id)
+    run_reaper_pass(active_run)
+    deadline = time.monotonic() + timeout
+    while True:
+        event = next_event(active_run)
+        if event is not None:
+            _emit_delivered(
+                event, as_json=as_json, cursor_before=load_cursor(active_run)
+            )
+            raise typer.Exit(code=EXIT_DELIVERED)
+        if not wait:
+            typer.echo("No pending events.", err=True)
+            raise typer.Exit(code=EXIT_NONE_PENDING)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            typer.echo(f"No event arrived within {timeout:g}s.", err=True)
+            raise typer.Exit(code=EXIT_TIMEOUT)
+        time.sleep(min(0.05, remaining))
+
+
+next_command.__doc__ = _NEXT_HELP
+
+
+def ack_command(
+    event_id: str = typer.Argument(..., help="Event id (the event filename)."),
+    run_id: str | None = typer.Option(None, "--run-id", help="Defaults to latest run."),
+) -> None:
+    active_run = _resolve_run_id(run_id)
+    try:
+        advanced = ack(active_run, event_id)
+    except AckRejected as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=EXIT_ACK_REJECTED) from exc
+    if advanced:
+        typer.echo(f"Acked {event_id}.")
+    else:
+        typer.echo(f"{event_id} already acked; cursor unchanged.")
+
+
+ack_command.__doc__ = _ACK_HELP

--- a/src/pydantic_ai_gepa/cli/events.py
+++ b/src/pydantic_ai_gepa/cli/events.py
@@ -22,8 +22,10 @@ or ack accepted, 1 run resolution/usage error, 3 no pending events, 4
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
+import sys
 import tempfile
 import threading
 import time
@@ -90,7 +92,9 @@ _TIMESTAMP_WIDTH = 13  # zero-padded epoch milliseconds
 _SEQ_WIDTH = 6
 _PRODUCER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _EVENT_ID_RE = re.compile(
-    rf"^(\d{{{_TIMESTAMP_WIDTH}}})-([A-Za-z0-9][A-Za-z0-9._-]*)-(\d{{{_SEQ_WIDTH}}})$"
+    # Seq is zero-padded to _SEQ_WIDTH but allowed to overflow it: ordering
+    # stays lexicographic within one ms-timestamp bucket.
+    rf"^(\d{{{_TIMESTAMP_WIDTH}}})-([A-Za-z0-9][A-Za-z0-9._-]*)-(\d{{{_SEQ_WIDTH},}})$"
 )
 
 # Per-process (run dir, producer id) -> next sequence number, guarded by a lock
@@ -115,6 +119,11 @@ def _validate_scalar_or_scalar_list(value: Any, *, field_name: str) -> None:
         for item in value:
             _validate_scalar_or_scalar_list(item, field_name=field_name)
         return
+    if isinstance(value, float) and not math.isfinite(value):
+        raise EventError(
+            f"Payload field {field_name!r} must be a finite number; got "
+            f"{value!r}. Non-finite floats are not JSON-representable."
+        )
     if value is None or isinstance(value, (str, int, float, bool)):
         return
     raise EventError(
@@ -149,6 +158,11 @@ def _validate_draft(type: str, lane: str | None, payload: dict[str, Any]) -> Non
             raise EventError(f"Run-scoped event {type!r} must carry lane=None.")
     elif lane is None:
         raise EventError(f"Lane-scoped event {type!r} requires a lane id.")
+    if lane is not None and not _PRODUCER_ID_RE.match(lane):
+        raise EventError(
+            f"Invalid lane id {lane!r}; expected filename-safe "
+            f"{_PRODUCER_ID_RE.pattern!r} (lane ids flow into paths downstream)."
+        )
 
 
 @dataclass(frozen=True)
@@ -204,10 +218,40 @@ def cursor_path(run_id: str, root: Path | None = None) -> Path:
     return run_dir(run_id, root) / CURSOR_FILENAME
 
 
-def _read_event(path: Path) -> Event:
-    data = json.loads(path.read_text(encoding="utf-8"))
-    data.setdefault("id", path.name)
-    return Event.from_dict(data)
+def _read_event(path: Path) -> Event | None:
+    """Read one event file; unparseable files quarantine as ``None``.
+
+    The filename *is* the event id (spec-fmc Interface block) — an embedded
+    ``id`` field that disagrees with the filename is corruption, so the
+    filename wins unconditionally. Producer tmpfiles (``.emit-*.tmp``) and
+    any other non-conforming names are not events.
+    """
+    if not _EVENT_ID_RE.match(path.name):
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        print(
+            f"warning: ignoring unparseable event file {path.name} "
+            "(a producer was likely killed mid-emit)",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        return None
+    embedded = data.get("id")
+    if embedded is not None and embedded != path.name:
+        print(
+            f"warning: event file {path.name} carries mismatched embedded id "
+            f"{embedded!r}; the filename is authoritative",
+            file=sys.stderr,
+        )
+    data["id"] = path.name
+    try:
+        return Event.from_dict(data)
+    except (KeyError, TypeError, ValueError):
+        print(f"warning: ignoring malformed event file {path.name}", file=sys.stderr)
+        return None
 
 
 def list_events(run_id: str, root: Path | None = None) -> list[Event]:
@@ -215,9 +259,11 @@ def list_events(run_id: str, root: Path | None = None) -> list[Event]:
     base = events_dir(run_id, root)
     if not base.is_dir():
         return []
-    events = [
-        _read_event(path) for path in sorted(base.iterdir(), key=lambda p: p.name)
-    ]
+    events = []
+    for path in sorted(base.iterdir(), key=lambda p: p.name):
+        event = _read_event(path)
+        if event is not None:
+            events.append(event)
     events.sort(key=lambda event: event.id)
     return events
 
@@ -226,11 +272,26 @@ def list_events(run_id: str, root: Path | None = None) -> list[Event]:
 
 
 def load_cursor(run_id: str, root: Path | None = None) -> str | None:
-    """Return the highest acked event id, or ``None`` when nothing was acked."""
+    """Return the highest acked event id, or ``None`` when nothing was acked.
+
+    A torn cursor (consumer killed mid-write) resets to ``None`` with a
+    warning — every event is redelivered, which at-least-once delivery makes
+    safe. A crashed cursor never wedges the bus.
+    """
     path = cursor_path(run_id, root)
     if not path.exists():
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        print(
+            f"warning: cursor file {path} is unreadable; resetting to "
+            "start-of-stream (unacked events will be redelivered)",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        return None
     acked = data.get("acked_id")
     return str(acked) if acked else None
 
@@ -335,15 +396,24 @@ def emit(
         event_id = f"{ts_ms}-{producer_id}-{seq:0{_SEQ_WIDTH}d}"
         file_path = path / event_id
         record = {"id": event_id, **body}
+        # Write to a sibling tmp file first, then exclusive-link into place:
+        # a producer killed mid-write leaves an ignored tmpfile, never a
+        # torn event file that would wedge every consumer (dec-f1s).
+        fd, tmp_name = tempfile.mkstemp(dir=str(path), prefix=".emit-", suffix=".tmp")
         try:
-            with file_path.open("x", encoding="utf-8") as handle:
-                json.dump(record, handle, indent=2)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(record, handle, indent=2, allow_nan=False)
                 handle.write("\n")
+            os.link(tmp_name, file_path)  # atomic + exclusive: EEXIST on collision
+            os.unlink(tmp_name)
             return event_id
         except FileExistsError:
+            os.unlink(tmp_name)
             # Timestamp collision with another emit: retry with the seq bumped.
             _bump_seq_past(path, producer_id, seq)
-        except OSError:
+        except BaseException:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
             _release_seq(path, producer_id, seq)
             raise
 
@@ -354,8 +424,16 @@ def emit(
 def next_event(run_id: str, root: Path | None = None) -> Event | None:
     """Return the oldest unacked event (id > cursor), or ``None`` if none."""
     cursor = load_cursor(run_id, root)
-    for event in list_events(run_id, root):
-        if cursor is None or event.id > cursor:
+    base = events_dir(run_id, root)
+    if not base.is_dir():
+        return None
+    # Filenames are ids (spec-fmc), so acked events are skipped by name
+    # without parsing — the poll path stays O(pending), not O(total).
+    for name in sorted(p.name for p in base.iterdir()):
+        if cursor is not None and name <= cursor:
+            continue
+        event = _read_event(base / name)
+        if event is not None:
             return event
     return None
 
@@ -369,6 +447,14 @@ def ack(run_id: str, event_id: str, root: Path | None = None) -> bool:
     """
     cursor = load_cursor(run_id, root)
     if cursor is not None and event_id <= cursor:
+        # Idempotent no-op only for events that actually exist — acking a
+        # never-existent id below the cursor (e.g. a mangled id) is an error
+        # the exit-code contract exists to catch.
+        if event_id != cursor and not (events_dir(run_id, root) / event_id).exists():
+            raise AckRejected(
+                f"Refusing to ack {event_id!r}: no such event on the bus "
+                "(and it is not the recorded cursor position)."
+            )
         return False
     pending = next_event(run_id, root)
     if pending is None:
@@ -431,6 +517,25 @@ def scan_lanes(run_id: str, root: Path | None = None) -> LaneScan:
     return LaneScan()
 
 
+def _claim_reaper_key(events_path: Path, key: str) -> bool:
+    """Atomically claim a reaper dedupe key; False when already claimed.
+
+    The dedupe key is a filesystem fact, not a read: exclusive-creating a
+    sentinel file per key makes synthesis idempotent across CONCURRENT
+    consumer verbs (gepa next / run status / select all reap), where a
+    scan-then-emit check would race (spec-fmc: no duplicate for the same
+    (lane, lease epoch) "no matter how many passes run").
+    """
+    sentinels = events_path / ".reaped"
+    sentinels.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(sentinels / key, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    except FileExistsError:
+        return False
+    os.close(fd)
+    return True
+
+
 def run_reaper_pass(
     run_id: str,
     scan: LaneScan | None = None,
@@ -440,26 +545,21 @@ def run_reaper_pass(
 ) -> list[str]:
     """Synthesize ``lane_stalled`` / ``selection_due`` events from a scan result.
 
-    Idempotent: before emitting, existing event files are checked for an event
-    with the same key — ``(lane_stalled, lane, payload.lease_epoch)`` or
-    ``(selection_due, lane=None, payload.iteration)`` — so no matter how many
-    passes run, a (lane, lease epoch) pair never produces a duplicate.
-    Returns the ids of events emitted by this pass.
+    Idempotent under both sequential and concurrent passes: each synthesis
+    first exclusive-creates a sentinel keyed ``(lane_stalled, lane,
+    lease_epoch)`` or ``(selection_due, iteration)``; only the pass that
+    wins the create emits. Returns the ids of events emitted by this pass.
     """
     if scan is None:
         scan = scan_lanes(run_id, root)
-    existing = list_events(run_id, root)
+    events_path = events_dir(run_id, root)
+    events_path.mkdir(parents=True, exist_ok=True)
     emitted: list[str] = []
     for lane in scan.lanes:
         if lane.stalled_reason is None:
             continue
-        duplicate = any(
-            event.type == "lane_stalled"
-            and event.lane == lane.lane
-            and event.payload.get("lease_epoch") == lane.lease_epoch
-            for event in existing
-        )
-        if duplicate:
+        key = f"lane_stalled-{lane.lane}-e{lane.lease_epoch}"
+        if not _claim_reaper_key(events_path, key):
             continue
         emitted.append(
             emit(
@@ -478,13 +578,8 @@ def run_reaper_pass(
         )
     if scan.selection_due is not None:
         signal = scan.selection_due
-        duplicate = any(
-            event.type == "selection_due"
-            and event.lane is None
-            and event.payload.get("iteration") == signal.iteration
-            for event in existing
-        )
-        if not duplicate:
+        key = f"selection_due-i{signal.iteration}"
+        if _claim_reaper_key(events_path, key):
             emitted.append(
                 emit(
                     run_id,

--- a/tests/cli/test_events_cli.py
+++ b/tests/cli/test_events_cli.py
@@ -15,16 +15,19 @@ from pydantic_ai_gepa.cli.events import (
     EXIT_ACK_REJECTED,
     EXIT_NONE_PENDING,
     EXIT_TIMEOUT,
+    AckRejected,
     EventDraft,
     EventError,
     LaneScan,
     LaneScanResult,
     SelectionDueSignal,
     ack,
+    cursor_path,
     emit,
     events_dir,
     list_events,
     load_cursor,
+    next_event,
     run_reaper_pass,
     scan_lanes,
 )
@@ -400,3 +403,168 @@ def test_help_documents_exit_codes() -> None:
         assert "Exit codes:" in result.output
     assert "4" in _run("next", "--help").output  # timeout code documented
     assert "5" in _run("ack", "--help").output  # rejected-ack code documented
+
+
+# ---------- adversarial-review hardening (PR #28 review) ----------
+
+
+def _draft(event_type: str = "verdict", lane: str | None = "lane-1") -> EventDraft:
+    payload = {"verdict": "accepted", "delta": 0.5, "comparison_path": "/tmp/c.json"}
+    return EventDraft(type=event_type, lane=lane, payload=payload)
+
+
+def test_partial_event_file_does_not_wedge_bus(tmp_path: Path) -> None:
+    """A producer killed mid-emit leaves an ignored tmpfile / quarantined
+    file — next, ack, and the reaper keep working."""
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    events_base = events_dir(run, tmp_path)
+    events_base.mkdir(parents=True)
+
+    # Torn event file with a valid event-id name (SIGKILL between create and flush).
+    (events_base / "1786000000000-lane-1-000000").write_text('{"type": "verd')
+    # Stray non-event files.
+    (events_base / ".emit-xyz.tmp").write_text("{}")
+    (events_base / "notes.txt").write_text("hello")
+
+    good = emit(run, "lane-1", _draft(), root=tmp_path)
+    event = next_event(run, tmp_path)
+    assert event is not None and event.id == good
+    assert ack(run, good, root=tmp_path) is True
+    assert next_event(run, tmp_path) is None
+
+
+def test_embedded_id_mismatch_loses_to_filename(tmp_path: Path) -> None:
+    """The filename is the id (spec-fmc); a mismatched embedded id never
+    hijacks delivery order."""
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    events_base = events_dir(run, tmp_path)
+    events_base.mkdir(parents=True)
+    (events_base / "1786000000000-lane-1-000000").write_text(
+        json.dumps(
+            {
+                "id": "9999999999999-evil-000000",
+                "type": "verdict",
+                "ts": "2026-01-01T00:00:00+00:00",
+                "lane": "lane-1",
+                "payload": {
+                    "verdict": "accepted",
+                    "delta": 1.0,
+                    "comparison_path": "/tmp/c.json",
+                },
+            }
+        )
+    )
+    event = next_event(run, tmp_path)
+    assert event is not None
+    assert event.id == "1786000000000-lane-1-000000"
+
+
+def test_corrupt_cursor_resets_to_start(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    event_id = emit(run, "lane-1", _draft(), root=tmp_path)
+    cursor_path(run, tmp_path).write_text("{torn", encoding="utf-8")
+
+    # The event is redelivered instead of the bus wedging.
+    event = next_event(run, tmp_path)
+    assert event is not None and event.id == event_id
+
+
+def test_ack_nonexistent_id_below_cursor_rejected(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    first = emit(run, "lane-1", _draft(), root=tmp_path)
+    assert ack(run, first, root=tmp_path) is True
+
+    import pytest as _pytest
+
+    bogus = (
+        first[:-6] + "999999"
+    )  # same prefix, never existed, sorts at/after cursor...
+    # craft an id that sorts below the cursor
+    bogus = "1000000000000-lane-1-000000"
+    assert bogus < first
+    with _pytest.raises(AckRejected):
+        ack(run, bogus, root=tmp_path)
+    # The real cursor id remains an idempotent no-op.
+    assert ack(run, first, root=tmp_path) is False
+
+
+def test_nonfinite_float_payload_rejected() -> None:
+    import pytest as _pytest
+
+    with _pytest.raises(EventError):
+        EventDraft(
+            type="verdict",
+            lane="lane-1",
+            payload={
+                "verdict": "accepted",
+                "delta": float("nan"),
+                "comparison_path": "/tmp/c.json",
+            },
+        )
+    with _pytest.raises(EventError):
+        EventDraft(
+            type="verdict",
+            lane="lane-1",
+            payload={
+                "verdict": "accepted",
+                "delta": float("inf"),
+                "comparison_path": "/tmp/c.json",
+            },
+        )
+
+
+def test_invalid_lane_id_rejected() -> None:
+    import pytest as _pytest
+
+    with _pytest.raises(EventError):
+        EventDraft(
+            type="verdict",
+            lane="../../etc",
+            payload={
+                "verdict": "accepted",
+                "delta": 0.1,
+                "comparison_path": "/tmp/c.json",
+            },
+        )
+
+
+def test_reaper_sentinel_dedupes_concurrent_passes(tmp_path: Path) -> None:
+    """Two concurrent reaper passes over the same scan emit exactly one
+    lane_stalled — the dedupe key is an exclusive-create sentinel, not a
+    read (spec-fmc: no duplicate no matter how many passes run)."""
+    import threading
+
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    scan = LaneScan(
+        lanes=(LaneScanResult(lane="lane-1", lease_epoch=3, stalled_reason="pid dead"),)
+    )
+
+    emitted: list[list[str]] = []
+
+    def pass_() -> None:
+        emitted.append(run_reaper_pass(run, scan, root=tmp_path))
+
+    threads = [threading.Thread(target=pass_) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    total = [event_id for batch in emitted for event_id in batch]
+    assert len(total) == 1
+    stalled = [
+        event for event in list_events(run, tmp_path) if event.type == "lane_stalled"
+    ]
+    assert len(stalled) == 1
+    assert stalled[0].payload["lease_epoch"] == 3
+
+    # A fresh lease epoch re-emits (new sentinel key).
+    scan2 = LaneScan(
+        lanes=(LaneScanResult(lane="lane-1", lease_epoch=4, stalled_reason="pid dead"),)
+    )
+    assert len(run_reaper_pass(run, scan2, root=tmp_path)) == 1

--- a/tests/cli/test_events_cli.py
+++ b/tests/cli/test_events_cli.py
@@ -1,0 +1,402 @@
+"""Tests for the managed-run event bus (`gepa next` / `gepa ack`, spec-fmc)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from typer.testing import CliRunner
+
+from pydantic_ai_gepa.cli import app as gepa_app
+from pydantic_ai_gepa.cli.events import (
+    EXIT_ACK_REJECTED,
+    EXIT_NONE_PENDING,
+    EXIT_TIMEOUT,
+    EventDraft,
+    EventError,
+    LaneScan,
+    LaneScanResult,
+    SelectionDueSignal,
+    ack,
+    emit,
+    events_dir,
+    list_events,
+    load_cursor,
+    run_reaper_pass,
+    scan_lanes,
+)
+from pydantic_ai_gepa.cli.layout import ensure_layout, new_run_id
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    monkeypatch.chdir(tmp_path)
+    ensure_layout(tmp_path)
+    yield tmp_path
+
+
+@pytest.fixture
+def run_id(repo: Path) -> str:
+    return new_run_id()
+
+
+def _run(*argv: str) -> object:
+    return CliRunner().invoke(gepa_app, list(argv))
+
+
+def _lane_ready_payload() -> dict[str, str]:
+    return {
+        "packet_path": "runs/x/lanes/lane-a/packet.json",
+        "worktree_path": "worktrees/lane-a",
+    }
+
+
+def _dead_lane_scan(
+    lane: str = "lane-a", lease_epoch: int = 1, reason: str = "heartbeat_stale"
+) -> LaneScan:
+    return LaneScan(
+        lanes=(
+            LaneScanResult(lane=lane, lease_epoch=lease_epoch, stalled_reason=reason),
+        )
+    )
+
+
+# ----------------------------- emit / storage ---------------------------
+
+
+def test_event_files_land_one_per_event_under_events_dir(
+    repo: Path, run_id: str
+) -> None:
+    first = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    second = emit(
+        run_id,
+        "lane-b",
+        EventDraft(
+            "verdict",
+            "lane-b",
+            {"verdict": "keep", "delta": 0.5, "comparison_path": "p"},
+        ),
+    )
+    files = sorted(p.name for p in events_dir(run_id, repo).iterdir())
+    assert files == sorted([first, second])
+    record = json.loads((events_dir(run_id, repo) / first).read_text())
+    assert record["id"] == first
+    assert record["type"] == "lane_ready"
+    assert record["lane"] == "lane-a"
+    assert record["payload"] == _lane_ready_payload()
+    assert record["ts"]
+
+
+def test_run_scoped_events_require_null_lane(repo: Path, run_id: str) -> None:
+    with pytest.raises(EventError, match="lane=None"):
+        EventDraft("run_done", "lane-a", {"final_report_path": "report.md"})
+    with pytest.raises(EventError, match="requires a lane"):
+        EventDraft("lane_stalled", None, {"reason": "x", "lease_epoch": 1})
+
+
+def test_emit_rejects_inline_non_scalar_payload(repo: Path, run_id: str) -> None:
+    with pytest.raises(EventError, match="path or scalar"):
+        EventDraft(
+            "verdict",
+            "lane-a",
+            {"verdict": "keep", "delta": 0.1, "comparison_path": {"nested": "inline"}},
+        )
+    # Validation happens at draft construction — nothing touches the disk.
+    assert not events_dir(run_id, repo).exists()
+
+
+def test_emit_rejects_missing_and_unknown_payload_fields(
+    repo: Path, run_id: str
+) -> None:
+    with pytest.raises(EventError, match="missing payload fields"):
+        EventDraft("budget_low", None, {})
+    with pytest.raises(EventError, match="unknown payload fields"):
+        EventDraft(
+            "lane_ready", "lane-a", {**_lane_ready_payload(), "extra_trace": "..."}
+        )
+
+
+def test_per_producer_seq_survives_fresh_state(repo: Path, run_id: str) -> None:
+    """A new producer process derives its seq from existing files (no 0-reuse)."""
+    from pydantic_ai_gepa.cli import events as events_mod
+
+    first = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    events_mod._seq_counters.clear()  # simulate a fresh producer process
+    second = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    assert first != second
+    assert int(second.rsplit("-", 1)[1]) == int(first.rsplit("-", 1)[1]) + 1
+
+
+def test_concurrent_producers_create_every_event_exactly_once(
+    repo: Path, run_id: str
+) -> None:
+    """N threaded producers: exclusive create => every event exactly once,
+    all ids unique, and replay order is lexicographic."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    producers = [f"lane-{chr(ord('a') + i)}" for i in range(8)]
+    per_producer = 10
+
+    def produce(producer: str) -> list[str]:
+        return [
+            emit(
+                run_id,
+                producer,
+                EventDraft("lane_ready", producer, _lane_ready_payload()),
+            )
+            for _ in range(per_producer)
+        ]
+
+    with ThreadPoolExecutor(max_workers=len(producers)) as pool:
+        results = list(pool.map(produce, producers))
+
+    emitted = [event_id for ids in results for event_id in ids]
+    assert len(emitted) == len(producers) * per_producer
+    assert len(set(emitted)) == len(emitted)
+    files = [p.name for p in events_dir(run_id, repo).iterdir()]
+    assert sorted(files) == sorted(emitted)
+    assert len(files) == len(emitted)  # each event created exactly once
+    replayed = [event.id for event in list_events(run_id, repo)]
+    assert replayed == sorted(emitted)
+
+
+# ----------------------------- next / redelivery ------------------------
+
+
+def test_next_redelivers_verbatim_until_acked(repo: Path, run_id: str) -> None:
+    """Crash between next and ack => the same event comes back byte-identical."""
+    event_id = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    first = _run("next", "--run-id", run_id, "--json")
+    assert first.exit_code == 0, first.output
+    second = _run("next", "--run-id", run_id, "--json")  # consumer "restarted"
+    assert second.exit_code == 0
+    assert second.output == first.output
+    record = json.loads(first.output)
+    assert record["id"] == event_id
+
+    acked = _run("ack", event_id, "--run-id", run_id)
+    assert acked.exit_code == 0, acked.output
+    drained = _run("next", "--run-id", run_id, "--json")
+    assert drained.exit_code == EXIT_NONE_PENDING
+
+
+def test_next_delivers_oldest_unacked_in_lexicographic_order(
+    repo: Path, run_id: str
+) -> None:
+    ids = [
+        emit(
+            run_id,
+            f"lane-{c}",
+            EventDraft("lane_ready", f"lane-{c}", _lane_ready_payload()),
+        )
+        for c in "abc"
+    ]
+    delivered = []
+    for expected in sorted(ids):
+        result = _run("next", "--run-id", run_id, "--json")
+        assert result.exit_code == 0
+        delivered.append(json.loads(result.output)["id"])
+        assert _run("ack", expected, "--run-id", run_id).exit_code == 0
+    assert delivered == sorted(ids)
+
+
+def test_next_wait_times_out_with_distinct_exit_code(repo: Path, run_id: str) -> None:
+    started = time.monotonic()
+    result = _run("next", "--run-id", run_id, "--wait", "--timeout", "0.2")
+    elapsed = time.monotonic() - started
+    assert result.exit_code == EXIT_TIMEOUT
+    assert "timeout" in result.output.lower() or "within" in result.output.lower()
+    assert elapsed >= 0.2
+    assert elapsed < 2.0  # never blocks past the timeout
+
+
+def test_next_without_wait_reports_none_pending(repo: Path, run_id: str) -> None:
+    result = _run("next", "--run-id", run_id)
+    assert result.exit_code == EXIT_NONE_PENDING
+    assert "No pending events" in result.output
+
+
+def test_next_wait_delivers_event_arriving_mid_poll(repo: Path, run_id: str) -> None:
+    import threading
+
+    def delayed_emit() -> None:
+        time.sleep(0.15)
+        emit(
+            run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+        )
+
+    thread = threading.Thread(target=delayed_emit)
+    thread.start()
+    result = _run("next", "--run-id", run_id, "--wait", "--timeout", "2", "--json")
+    thread.join()
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["type"] == "lane_ready"
+
+
+def test_next_human_output_names_ack_command(repo: Path, run_id: str) -> None:
+    event_id = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    result = _run("next", "--run-id", run_id)
+    assert result.exit_code == 0
+    assert event_id in result.output
+    assert f"gepa ack {event_id}" in result.output
+
+
+def test_next_without_run_id_picks_latest(repo: Path) -> None:
+    older = "20260101T000000Z-aaaaaaaa"
+    newer = "20260102T000000Z-bbbbbbbb"
+    emit(
+        older,
+        "lane-a",
+        EventDraft("lane_ready", "lane-a", _lane_ready_payload()),
+        root=repo,
+    )
+    emit(
+        newer,
+        "lane-b",
+        EventDraft("lane_ready", "lane-b", _lane_ready_payload()),
+        root=repo,
+    )
+    result = _run("next", "--json")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["lane"] == "lane-b"
+
+
+def test_next_errors_when_no_runs(repo: Path) -> None:
+    result = _run("next")
+    assert result.exit_code == 1
+    assert "No runs found" in result.output
+
+
+# ----------------------------- ack semantics ----------------------------
+
+
+def test_ack_advances_persisted_cursor(repo: Path, run_id: str) -> None:
+    event_id = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    assert load_cursor(run_id, repo) is None
+    assert ack(run_id, event_id, root=repo) is True
+    assert load_cursor(run_id, repo) == event_id
+
+
+def test_ack_of_non_oldest_is_rejected(repo: Path, run_id: str) -> None:
+    first = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    second = emit(
+        run_id, "lane-b", EventDraft("lane_ready", "lane-b", _lane_ready_payload())
+    )
+    result = _run("ack", second, "--run-id", run_id)
+    assert result.exit_code == EXIT_ACK_REJECTED
+    assert first in result.output  # names the oldest unacked event
+    assert load_cursor(run_id, repo) is None
+
+
+def test_second_ack_of_same_id_is_noop_success(repo: Path, run_id: str) -> None:
+    event_id = emit(
+        run_id, "lane-a", EventDraft("lane_ready", "lane-a", _lane_ready_payload())
+    )
+    assert _run("ack", event_id, "--run-id", run_id).exit_code == 0
+    result = _run("ack", event_id, "--run-id", run_id)
+    assert result.exit_code == 0, result.output
+    assert "already acked" in result.output
+    assert load_cursor(run_id, repo) == event_id
+
+
+def test_ack_unknown_id_is_rejected(repo: Path, run_id: str) -> None:
+    result = _run("ack", "0000000000000-ghost-000000", "--run-id", run_id)
+    assert result.exit_code == EXIT_ACK_REJECTED
+
+
+# ----------------------------- reaper pass ------------------------------
+
+
+def test_scan_lanes_stub_reports_no_lanes(repo: Path, run_id: str) -> None:
+    scan = scan_lanes(run_id, repo)
+    assert scan.lanes == ()
+    assert scan.selection_due is None
+    assert run_reaper_pass(run_id, root=repo) == []
+
+
+def test_reaper_synthesizes_lane_stalled_exactly_once_per_lease_epoch(
+    repo: Path, run_id: str
+) -> None:
+    scan = _dead_lane_scan()
+    first_pass = run_reaper_pass(run_id, scan, root=repo)
+    assert len(first_pass) == 1
+    second_pass = run_reaper_pass(run_id, scan, root=repo)
+    assert second_pass == []
+    stalled = [e for e in list_events(run_id, repo) if e.type == "lane_stalled"]
+    assert len(stalled) == 1
+    assert stalled[0].lane == "lane-a"
+    assert stalled[0].payload == {"reason": "heartbeat_stale", "lease_epoch": 1}
+
+
+def test_reaper_emits_again_for_fresh_lease_epoch(repo: Path, run_id: str) -> None:
+    run_reaper_pass(run_id, _dead_lane_scan(lease_epoch=1), root=repo)
+    emitted = run_reaper_pass(run_id, _dead_lane_scan(lease_epoch=2), root=repo)
+    assert len(emitted) == 1
+    epochs = [
+        e.payload["lease_epoch"]
+        for e in list_events(run_id, repo)
+        if e.type == "lane_stalled"
+    ]
+    assert sorted(epochs) == [1, 2]
+
+
+def test_reaper_synthesizes_selection_due_with_resolved_and_stragglers(
+    repo: Path, run_id: str
+) -> None:
+    scan = LaneScan(
+        selection_due=SelectionDueSignal(
+            iteration=3,
+            resolved_lanes=("lane-a", "lane-b"),
+            straggler_lanes=("lane-c",),
+        )
+    )
+    emitted = run_reaper_pass(run_id, scan, root=repo)
+    assert len(emitted) == 1
+    assert run_reaper_pass(run_id, scan, root=repo) == []  # idempotent
+    due = [e for e in list_events(run_id, repo) if e.type == "selection_due"]
+    assert len(due) == 1
+    assert due[0].lane is None
+    assert due[0].payload == {
+        "iteration": 3,
+        "resolved_lanes": ["lane-a", "lane-b"],
+        "straggler_lanes": ["lane-c"],
+    }
+
+
+def test_next_runs_reaper_pass_before_delivering(
+    repo: Path, run_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pydantic_ai_gepa.cli import events as events_mod
+
+    monkeypatch.setattr(events_mod, "scan_lanes", lambda *a, **k: _dead_lane_scan())
+    result = _run("next", "--run-id", run_id, "--json")
+    assert result.exit_code == 0, result.output
+    record = json.loads(result.output)
+    assert record["type"] == "lane_stalled"
+    assert record["lane"] == "lane-a"
+
+
+def test_help_documents_exit_codes() -> None:
+    for verb in ("next", "ack"):
+        result = _run(verb, "--help")
+        assert result.exit_code == 0
+        assert "Exit codes:" in result.output
+    assert "4" in _run("next", "--help").output  # timeout code documented
+    assert "5" in _run("ack", "--help").output  # rejected-ack code documented


### PR DESCRIPTION
## Stack position: 2/5 — base: `lanes/1-pareto-ledger` (#27)

Implements pydanticaigepa-task-r8c — the managed-run event bus slice of the reflection-lanes stack.

### Governing contracts (accepted on `main`)

- **spec-fmc** — event record shape, next/ack verbs, persisted cursor, at-least-once redelivery.
- **dec-f1s** — one file per event, exclusive create, producer-unique filename ids; no shared append.
- **dec-pm3** — lazy reaper: consumer verbs synthesize `lane_stalled`/`selection_due` idempotently keyed by (lane, lease epoch).

### What changes

- **New `cli/events.py`** (~615 lines):
  - `Event`/`EventDraft` for all seven spec types; payload validation at draft construction (exact key sets per the spec-fmc Interface block; scalars + scalar lists only — inline content rejected before any file is touched).
  - `emit()`: exclusive create (`open('x')`); id = `<13-digit ms>-<producer>-<6-digit seq>`; seq derived from existing files for fresh processes + a locked in-process counter for threads; ms-collision retries with seq bump. Uniqueness by construction, no read-modify-write.
  - `cursor.json` (atomic tmp+replace); `next_event()` = oldest unacked in lexicographic id order; `ack()` idempotent, non-oldest ack rejected.
  - `run_reaper_pass(scan)` consuming a `LaneScan` result object; `lane_stalled` dedupe keyed by (lane, lease_epoch); `selection_due` (run-scoped, no lease epoch exists) keyed by iteration — documented in the docstring. `scan_lanes()` is the stubbed seam slice 3 (task-xcb) replaces with the real lane-state scanner.
- **CLI**: top-level `gepa next [--wait --timeout N --json]` and `gepa ack <id>`. `gepa next` runs the reaper pass first. Exit codes documented in `--help`: 0 delivered/ack-ok, 1 usage, 3 none-pending, 4 timeout (distinct from none-pending), 5 rejected ack.
- **Tests** (`tests/cli/test_events_cli.py`, 24 new): all seven spec-fmc Verifications — verbatim redelivery after crash, 8 threaded producers × 10 events (exactly-once files, unique ids, lexicographic replay), `--wait` timeout with exit 4, non-oldest ack exit 5, second ack no-op, inline-payload rejection, reaper idempotency across passes, selection_due synthesis, reaper-runs-first seam.

### Validation

`uv run pytest tests/cli -q` → 176 passed (152 pre-existing + 24 new). `ruff check` + `ruff format --check` clean.

### Out of scope (per task)

Lane state files and the real heartbeat/pid scanner (slice 3); emitting events from lane lifecycle verbs (slice 3); budget_low auto-emission and selection (slice 4).