### PR TITLE
Reflection lane lifecycle: worktrees, lane state, background lane continue (stack 3/5)

### DIFF
--- a/src/pydantic_ai_gepa/cli/__init__.py
+++ b/src/pydantic_ai_gepa/cli/__init__.py
@@ -15,6 +15,7 @@ from . import eval as eval_cmd
 from . import events as events_cmd
 from . import init as init_cmd
 from . import journal as journal_cmd
+from . import lanes as lanes_cmd
 from . import pareto as pareto_cmd
 from . import run as run_cmd
 from .layout import load_dotenv, set_gepa_dirname
@@ -77,6 +78,11 @@ app.command(name="pareto", help="Show Pareto front or full history (json or tsv)
 )
 app.command(name="next")(events_cmd.next_command)
 app.command(name="ack")(events_cmd.ack_command)
+app.add_typer(
+    lanes_cmd.app,
+    name="lane",
+    help="Drive reflection lanes: lease, continue (background eval), reset.",
+)
 app.add_typer(
     run_cmd.app,
     name="run",

--- a/src/pydantic_ai_gepa/cli/eval.py
+++ b/src/pydantic_ai_gepa/cli/eval.py
@@ -76,17 +76,17 @@ from .store import ComponentStore
 GEPA_TRACE_FILE_ENV = "GEPA_TRACE_FILE"
 
 
-def _resolve_run_id(run_id: str | None) -> str:
+def _resolve_run_id(run_id: str | None, root: Path | None = None) -> str:
     if run_id:
         return run_id
-    latest = latest_run_id()
+    latest = latest_run_id(root)
     if latest:
         return latest
     return new_run_id()
 
 
-def _count_evals_in_run(run_id: str) -> int:
-    return ParetoLog(run_id).count_rows()
+def _count_evals_in_run(run_id: str, root: Path | None = None) -> int:
+    return ParetoLog(run_id, root).count_rows()
 
 
 DEFAULT_FAILURE_THRESHOLD = 0.999
@@ -176,11 +176,12 @@ def _trace_file_path(
     eval_id: str,
     candidate_id: str,
     minibatch_id: str,
+    root: Path | None = None,
 ) -> Path:
     # eval_id guarantees uniqueness: identical candidate trees evaluated by
     # concurrent lanes share an iteration ordinal and candidate_id (dec-msy).
     return (
-        run_dir(run_id)
+        run_dir(run_id, root)
         / "traces"
         / "minibatches"
         / minibatch_id
@@ -230,6 +231,8 @@ def run_eval_once(
     capture_traces: bool = False,
     candidate_source: CandidateSource | None = None,
     lane: str | None = None,
+    candidate_root: Path | None = None,
+    workspace_root: Path | None = None,
 ) -> EvalOutcome:
     """Evaluate one baseline/candidate and append the standard run artifacts.
 
@@ -237,9 +240,14 @@ def run_eval_once(
     pareto row records it, and the ``max_iterations`` check becomes advisory —
     for lane runs the budget stop is enforced at select, not per-eval
     (pydanticaigepa-dec-msy).
+
+    Lane evals also pass ``workspace_root`` (the primary checkout holding the
+    ``.gepa`` workspace — config, dataset, ledger, and artifacts all resolve
+    there per pydanticaigepa-dec-780) and ``candidate_root`` (the lane
+    worktree — candidate identity and module imports resolve there).
     """
-    cfg = GepaConfig.load(config_path())
-    insert_repo_root_on_path()
+    cfg = GepaConfig.load(config_path(workspace_root))
+    insert_repo_root_on_path(candidate_root)
 
     source = candidate_source or cfg.candidate_source
     agent = resolve_agent(cfg) if cfg.agent else None
@@ -248,7 +256,7 @@ def run_eval_once(
     case_factory = resolve_case_factory(cfg)
     skills_fs = resolve_skills(cfg)
 
-    dataset_path = repo_root() / cfg.dataset
+    dataset_path = (workspace_root or repo_root()) / cfg.dataset
     cases = load_dataset(dataset_path)
     if not cases:
         typer.echo(f"Dataset {dataset_path} is empty.", err=True)
@@ -327,8 +335,8 @@ def run_eval_once(
             candidate_overrides_id = str(candidate_file)
             status = "evaluated"
 
-    active_run_id = _resolve_run_id(run_id)
-    prior_count = _count_evals_in_run(active_run_id)
+    active_run_id = _resolve_run_id(run_id, root=workspace_root)
+    prior_count = _count_evals_in_run(active_run_id, root=workspace_root)
     if prior_count >= max_iterations:
         if not lane:  # None (single path) or empty: hard cap; lane str: advisory
             typer.echo(
@@ -348,8 +356,8 @@ def run_eval_once(
     iteration = prior_count + 1
     eval_id = new_eval_id()
 
-    run_dir(active_run_id).mkdir(parents=True, exist_ok=True)
-    minibatch_store = MinibatchStore(active_run_id)
+    run_dir(active_run_id, workspace_root).mkdir(parents=True, exist_ok=True)
+    minibatch_store = MinibatchStore(active_run_id, workspace_root)
     if minibatch_id:
         minibatch = minibatch_store.load(minibatch_id)
     else:
@@ -370,7 +378,8 @@ def run_eval_once(
     if source == "git":
         try:
             git_state = git_candidate_state(
-                repo_root(), exclude_paths=[run_dir(active_run_id)]
+                candidate_root or repo_root(),
+                exclude_paths=[run_dir(active_run_id, workspace_root)],
             )
         except GitCandidateError as exc:
             typer.echo(str(exc), err=True)
@@ -395,6 +404,7 @@ def run_eval_once(
             eval_id=eval_id,
             candidate_id=candidate.id,
             minibatch_id=minibatch.id,
+            root=workspace_root,
         )
         if capture_traces
         else None
@@ -428,14 +438,14 @@ def run_eval_once(
     per_case = {record.case_id: record.score for record in records}
     mean = sum(per_case.values()) / len(per_case) if per_case else 0.0
 
-    pareto = ParetoLog(active_run_id)
+    pareto = ParetoLog(active_run_id, workspace_root)
     pareto.append(
         ParetoRow(
             candidate_id=candidate.id,
             commit_sha=(
                 git_state.commit_sha
                 if git_state is not None
-                else current_commit_sha(repo_root())
+                else current_commit_sha(candidate_root or repo_root())
             ),
             component_overrides_id=candidate_overrides_id,
             minibatch_id=minibatch.id,
@@ -450,7 +460,7 @@ def run_eval_once(
     )
 
     # Write the per-case report next to the pareto log.
-    reports_dir = run_dir(active_run_id) / "reports"
+    reports_dir = run_dir(active_run_id, workspace_root) / "reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
     report_path = reports_dir / f"{iteration:04d}-{eval_id}-{candidate.id}.md"
     report_path.write_text(
@@ -473,7 +483,7 @@ def run_eval_once(
         "commit_sha": (
             git_state.commit_sha
             if git_state is not None
-            else current_commit_sha(repo_root())
+            else current_commit_sha(candidate_root or repo_root())
         ),
         "dirty_tree": git_state.dirty if git_state is not None else None,
         "dirty_hash": git_state.dirty_hash if git_state is not None else None,

--- a/src/pydantic_ai_gepa/cli/events.py
+++ b/src/pydantic_ai_gepa/cli/events.py
@@ -509,12 +509,17 @@ class LaneScan:
 def scan_lanes(run_id: str, root: Path | None = None) -> LaneScan:
     """Scan lane leases, heartbeat freshness, and recorded pids.
 
-    Stubbed seam: lane state lands with the lane lifecycle
-    (pydanticaigepa-task-xcb), so until then every scan reports no lanes and
-    no selection pressure. The reaper pass consumes this result object; tests
-    and slice 3 inject real scans the same way.
+    Delegates to the lane-lifecycle scanner (pydanticaigepa-task-xcb) when the
+    run has lanes; single-path runs (and runs without lane state) scan as
+    empty. Imported lazily to avoid a module cycle (lanes imports this module
+    for ``emit``).
     """
-    return LaneScan()
+    try:
+        from .lanes import scan_run_lanes
+    except ImportError:
+        return LaneScan()
+    scan = scan_run_lanes(run_id, root=root)
+    return scan if scan is not None else LaneScan()
 
 
 def _claim_reaper_key(events_path: Path, key: str) -> bool:

--- a/src/pydantic_ai_gepa/cli/lanes.py
+++ b/src/pydantic_ai_gepa/cli/lanes.py
@@ -24,6 +24,7 @@ Key contracts:
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import re
@@ -32,6 +33,7 @@ import signal
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -71,8 +73,10 @@ def lane_ids(count: int) -> list[str]:
     return [f"lane-{i}" for i in range(1, count + 1)]
 
 
-def lane_branch(lane: str, iteration: int) -> str:
-    return f"{LANE_BRANCH_PREFIX}/{lane}/{iteration}"
+def lane_branch(run_id: str, lane: str, iteration: int) -> str:
+    """Run-scoped lane branch (dec-jh6): lane refs from different runs never
+    collide, and an abandoned run can never poison a future one."""
+    return f"{LANE_BRANCH_PREFIX}/{run_id}/{lane}/{iteration}"
 
 
 # ----------------------------- workspace resolution ---------------------
@@ -201,8 +205,28 @@ class LaneState:
     def save(self, workspace_root: Path, run_id: str) -> Path:
         path = lane_state_path(workspace_root, run_id, self.lane)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        _atomic_write_json(path, self.to_dict())
         return path
+
+
+@contextmanager
+def _lane_lock(workspace_root: Path, run_id: str, lane: str) -> Any:
+    """Exclusive flock on the lane's state dir (dec-l95).
+
+    Lease claims, the leased -> evaluating handoff, resets, and select's
+    re-fan all hold this lock, so concurrent verbs serialize on the
+    filesystem instead of racing read-then-write on state.json. The lock
+    auto-releases if the holder dies.
+    """
+    path = lane_state_path(workspace_root, run_id, lane)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path.parent / ".lane.lock", os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def lanes_dir(workspace_root: Path, run_id: str) -> Path:
@@ -213,13 +237,38 @@ def lane_state_path(workspace_root: Path, run_id: str, lane: str) -> Path:
     return lanes_dir(workspace_root, run_id) / lane / "state.json"
 
 
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON via sibling tmpfile + os.replace — a torn state file can
+    never wedge the verbs that read it."""
+    import tempfile
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        os.unlink(tmp_name)
+        raise
+
+
 def load_lane_state(workspace_root: Path, run_id: str, lane: str) -> LaneState:
     path = lane_state_path(workspace_root, run_id, lane)
     if not path.exists():
         raise typer.BadParameter(
             f"No lane state at {path}. Was this run started with --lanes?"
         )
-    return LaneState.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(
+            f"Lane state at {path} is corrupt ({exc.msg}); recover with "
+            f"`gepa lane reset {lane}` after verifying no eval is running."
+        ) from exc
+    return LaneState.from_dict(data)
 
 
 def load_all_lane_states(workspace_root: Path, run_id: str) -> list[LaneState]:
@@ -243,8 +292,9 @@ def worktrees_root(workspace_root: Path) -> Path:
     return workspace_root / WORKTREES_DIRNAME
 
 
-def lane_worktree_path(workspace_root: Path, lane: str) -> Path:
-    return worktrees_root(workspace_root) / lane
+def lane_worktree_path(workspace_root: Path, run_id: str, lane: str) -> Path:
+    """Run-scoped worktree path (dec-jh6)."""
+    return worktrees_root(workspace_root) / run_id / lane
 
 
 def ensure_worktrees_ignored(workspace_root: Path) -> None:
@@ -254,7 +304,16 @@ def ensure_worktrees_ignored(workspace_root: Path) -> None:
     and untracked, so `git ls-files --others --exclude-standard` (used by git
     candidate identity) skips lane worktrees automatically.
     """
-    info_dir = workspace_root / ".git" / "info"
+    git_path = workspace_root / ".git"
+    if git_path.is_file():
+        # Linked worktree as primary: .git is a gitdir pointer file; resolve
+        # the real git dir before writing info/exclude.
+        content = git_path.read_text(encoding="utf-8").strip()
+        if content.startswith("gitdir:"):
+            git_path = Path(content.split(":", 1)[1].strip())
+            if not git_path.is_absolute():
+                git_path = (workspace_root / git_path).resolve()
+    info_dir = git_path / "info"
     info_dir.mkdir(parents=True, exist_ok=True)
     exclude = info_dir / "exclude"
     entry = f"/{WORKTREES_DIRNAME}/"
@@ -277,8 +336,8 @@ def create_lane_worktree(
     workspace_root: Path, run_id: str, lane: str, iteration: int, base_sha: str
 ) -> tuple[Path, str]:
     """Create the lane worktree + branch cut from ``base_sha`` (the run's best)."""
-    branch = lane_branch(lane, iteration)
-    path = lane_worktree_path(workspace_root, lane)
+    branch = lane_branch(run_id, lane, iteration)
+    path = lane_worktree_path(workspace_root, run_id, lane)
     path.parent.mkdir(parents=True, exist_ok=True)
     _git(workspace_root, "worktree", "add", str(path), "-b", branch, base_sha)
     return path, branch
@@ -376,6 +435,14 @@ def _auto_commit_worktree(worktree: Path, branch: str, lane: str) -> str:
     Lane candidates are always clean commits because continue auto-commits
     (dec-tlz).
     """
+    current_branch = _git(worktree, "rev-parse", "--abbrev-ref", "HEAD")
+    if current_branch != branch:
+        # Check BEFORE committing: a commit on a rogue branch would silently
+        # lose the candidate from the lane's lineage.
+        raise typer.BadParameter(
+            f"Lane worktree {worktree} is on branch {current_branch!r}, "
+            f"expected {branch!r}; run `gepa lane reset {lane}` to recover."
+        )
     _git(worktree, "add", "-A")
     status = _git(worktree, "status", "--porcelain")
     if status:
@@ -388,12 +455,6 @@ def _auto_commit_worktree(worktree: Path, branch: str, lane: str) -> str:
             "commit",
             "-m",
             f"gepa lane continue: {lane} candidate",
-        )
-    current_branch = _git(worktree, "rev-parse", "--abbrev-ref", "HEAD")
-    if current_branch != branch:
-        raise typer.BadParameter(
-            f"Lane worktree {worktree} is on branch {current_branch!r}, "
-            f"expected {branch!r}; run `gepa lane reset {lane}` to recover."
         )
     return _git(worktree, "rev-parse", "HEAD")
 
@@ -474,6 +535,7 @@ def _run_lane_eval_loop(
             "verdict": None,
             "verdict_delta": None,
             "comparison_path": None,
+            "lease_expires_at": None,  # the handoff lease is consumed
         }
     )
     lane_state = _touch_heartbeat(workspace_root, run_id, lane_state, pid)
@@ -482,50 +544,60 @@ def _run_lane_eval_loop(
     max_candidate_samples = len(baseline_samples)
     initial_samples = min(run_state.acceptance_repetitions, max_candidate_samples)
 
+    # The candidate tree is the cwd for evaluation: `evaluate` callables and
+    # user metric code routinely read files by relative path, and those reads
+    # must observe the lane worktree, not the primary checkout (detached
+    # children are spawned with cwd=worktree; foreground callers are switched
+    # here so both paths evaluate the same tree).
+    previous_cwd = Path.cwd()
+    os.chdir(worktree)
     samples: list[float] = []
     outcomes: list[Any] = []
     comparison_result = None
-    for _ in range(max_candidate_samples):
-        outcome = run_eval_once(
-            candidate_file=None,
-            minibatch_id=run_state.reflection_minibatch_id,
-            size=run_state.size,
-            seed=run_state.seed,
-            epoch=run_state.next_epoch,
-            run_id=run_id,
-            concurrency=run_state.concurrency,
-            max_iterations=run_state.max_iterations,
-            threshold=run_state.threshold,
-            capture_traces=True,
-            candidate_source="git",
-            lane=lane,
-            candidate_root=worktree,
-            workspace_root=workspace_root,
-        )
-        outcomes.append(outcome)
-        current_id = str(outcome.summary["candidate_id"])
-        if current_id != git_state.candidate_id:
-            raise typer.BadParameter(
-                "The lane candidate changed mid-evaluation "
-                f"({git_state.candidate_id} -> {current_id}); refusing to "
-                "compare mixed candidates."
+    try:
+        for _ in range(max_candidate_samples):
+            outcome = run_eval_once(
+                candidate_file=None,
+                minibatch_id=run_state.reflection_minibatch_id,
+                size=run_state.size,
+                seed=run_state.seed,
+                epoch=run_state.next_epoch,
+                run_id=run_id,
+                concurrency=run_state.concurrency,
+                max_iterations=run_state.max_iterations,
+                threshold=run_state.threshold,
+                capture_traces=True,
+                candidate_source="git",
+                lane=lane,
+                candidate_root=worktree,
+                workspace_root=workspace_root,
             )
-        samples.append(float(outcome.summary["mean_score"]))
-        lane_state = LaneState(
-            **{**lane_state.to_dict(), "eval_samples": tuple(samples)}
-        )
-        lane_state = _touch_heartbeat(workspace_root, run_id, lane_state, pid)
+            outcomes.append(outcome)
+            current_id = str(outcome.summary["candidate_id"])
+            if current_id != git_state.candidate_id:
+                raise typer.BadParameter(
+                    "The lane candidate changed mid-evaluation "
+                    f"({git_state.candidate_id} -> {current_id}); refusing to "
+                    "compare mixed candidates."
+                )
+            samples.append(float(outcome.summary["mean_score"]))
+            lane_state = LaneState(
+                **{**lane_state.to_dict(), "eval_samples": tuple(samples)}
+            )
+            lane_state = _touch_heartbeat(workspace_root, run_id, lane_state, pid)
 
-        if len(samples) < initial_samples:
-            continue
-        comparison_result = compare_candidate_samples(
-            baseline_samples[: len(samples)],
-            tuple(samples),
-            confidence=run_state.acceptance_confidence,
-            min_delta=run_state.acceptance_min_delta,
-        )
-        if comparison_result.verdict != "inconclusive":
-            break
+            if len(samples) < initial_samples:
+                continue
+            comparison_result = compare_candidate_samples(
+                baseline_samples[: len(samples)],
+                tuple(samples),
+                confidence=run_state.acceptance_confidence,
+                min_delta=run_state.acceptance_min_delta,
+            )
+            if comparison_result.verdict != "inconclusive":
+                break
+    finally:
+        os.chdir(previous_cwd)
 
     assert comparison_result is not None
     comparison = {
@@ -550,6 +622,22 @@ def _run_lane_eval_loop(
     comparison_path = _write_comparison(
         workspace_root, run_id, lane, lane_state.iteration, comparison
     )
+    # State lands before the event: a crash between them must leave the
+    # verdict in lane state (select reads verdicts from state, not the bus),
+    # with the event redeliverable rather than a verdict event pointing at a
+    # lane that looks mid-eval.
+    lane_state = LaneState(
+        **{
+            **lane_state.to_dict(),
+            "status": "awaiting_selection",
+            "verdict": comparison_result.verdict,
+            "verdict_delta": comparison_result.delta,
+            "comparison_path": str(comparison_path),
+            "eval_pid": None,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    lane_state.save(workspace_root, run_id)
     verdict_id = emit(
         run_id,
         lane,
@@ -564,18 +652,6 @@ def _run_lane_eval_loop(
         ),
         root=workspace_root,
     )
-    lane_state = LaneState(
-        **{
-            **lane_state.to_dict(),
-            "status": "awaiting_selection",
-            "verdict": comparison_result.verdict,
-            "verdict_delta": comparison_result.delta,
-            "comparison_path": str(comparison_path),
-            "eval_pid": None,
-            "updated_at": utc_now_iso(),
-        }
-    )
-    lane_state.save(workspace_root, run_id)
     typer.echo(
         f"Lane {lane} verdict: {comparison_result.verdict} "
         f"(delta={comparison_result.delta:+.4f}); event {verdict_id}."
@@ -615,6 +691,13 @@ def _resolve_lane_run(run_id: str | None) -> tuple[Path, Any]:
             typer.echo("No runs found. Start one with `gepa run start`.", err=True)
             raise typer.Exit(code=1)
     run_state = _load_run_state(workspace_root, run_id)
+    if run_state.status == "done":
+        typer.echo(
+            f"Run {run_state.run_id} is done; lane verbs no longer apply "
+            "(a lane is re-fanned at select or removed when the run completes).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     if run_state.lanes < 1:
         typer.echo(
             f"Run {run_state.run_id} is not a lane run (started without --lanes); "
@@ -644,35 +727,43 @@ def lane_lease(
     """
     _validate_lane_id(lane)
     workspace_root, run_state = _resolve_lane_run(run_id)
-    state = load_lane_state(workspace_root, run_state.run_id, lane)
-    now = datetime.now(timezone.utc)
-    if state.status == "leased" and state.lease_expires_at:
-        if _parse_iso(state.lease_expires_at) > now:
+    with _lane_lock(workspace_root, run_state.run_id, lane):
+        state = load_lane_state(workspace_root, run_state.run_id, lane)
+        now = datetime.now(timezone.utc)
+        if state.status == "leased" and state.lease_expires_at:
+            if _parse_iso(state.lease_expires_at) > now:
+                typer.echo(
+                    f"Lane {lane} is already leased until {state.lease_expires_at} "
+                    f"(lease epoch {state.lease_epoch}); refusing re-dispatch.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+        if state.status == "evaluating":
             typer.echo(
-                f"Lane {lane} is already leased until {state.lease_expires_at} "
-                f"(lease epoch {state.lease_epoch}); refusing re-dispatch.",
+                f"Lane {lane} is evaluating (pid {state.eval_pid}); it cannot "
+                "be leased for dispatch.",
                 err=True,
             )
             raise typer.Exit(code=1)
-    if state.status not in {"paused_for_reflection", "leased"}:
-        typer.echo(
-            f"Lane {lane} is {state.status}; only paused_for_reflection lanes "
-            "can be leased for dispatch.",
-            err=True,
+        if state.status not in {"paused_for_reflection", "leased", "stalled"}:
+            typer.echo(
+                f"Lane {lane} is {state.status}; only paused_for_reflection "
+                "lanes can be leased for dispatch.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        expires = now.timestamp() + run_state.reflection_lease_secs
+        expires_at = datetime.fromtimestamp(expires, timezone.utc).isoformat()
+        state = LaneState(
+            **{
+                **state.to_dict(),
+                "status": "leased",
+                "lease_epoch": state.lease_epoch + 1,
+                "lease_expires_at": expires_at,
+                "updated_at": utc_now_iso(),
+            }
         )
-        raise typer.Exit(code=1)
-    expires = now.timestamp() + run_state.reflection_lease_secs
-    expires_at = datetime.fromtimestamp(expires, timezone.utc).isoformat()
-    state = LaneState(
-        **{
-            **state.to_dict(),
-            "status": "leased",
-            "lease_epoch": state.lease_epoch + 1,
-            "lease_expires_at": expires_at,
-            "updated_at": utc_now_iso(),
-        }
-    )
-    state.save(workspace_root, run_state.run_id)
+        state.save(workspace_root, run_state.run_id)
     typer.echo(
         f"Lane {lane} leased (epoch {state.lease_epoch}, expires {expires_at}). "
         f"Dispatch a reflector with the packet at {state.packet_path}."
@@ -696,52 +787,83 @@ def lane_continue(
     repeated-evaluation acceptance policy as a detached process that streams
     progress + heartbeat into lane state and emits a `verdict` event on
     resolution.
+
+    Lease discipline (dec-l95): continue requires a lease — an unexpired one
+    from `gepa lane lease`, or it auto-claims one for a paused/stalled lane.
+    A lane already evaluating rejects a second continue; a leased lane rejects
+    any continue that does not consume its lease. The claim and the handoff
+    are serialized by an flock on the lane state dir, and the handoff lease
+    expires after --eval-stall-timeout-secs so a child that dies before its
+    first heartbeat is reaped.
     """
     _validate_lane_id(lane)
     workspace_root, run_state = _resolve_lane_run(run_id)
-    state = load_lane_state(workspace_root, run_state.run_id, lane)
+    now = datetime.now(timezone.utc)
 
-    if state.status == "evaluating":
-        typer.echo(
-            f"Lane {lane} is already evaluating (pid {state.eval_pid}); a "
-            "leased/evaluating lane rejects a second concurrent "
-            "`gepa lane continue`.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    if state.status not in {"paused_for_reflection", "leased", "stalled"}:
-        typer.echo(
-            f"Lane {lane} is {state.status}; `gepa lane continue` expects a "
-            "paused_for_reflection (or leased) lane.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    if not state.worktree_path or not state.branch:
-        typer.echo(
-            f"Lane {lane} has no worktree/branch recorded; run "
-            f"`gepa lane reset {lane}` to re-fan it.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
+    with _lane_lock(workspace_root, run_state.run_id, lane):
+        state = load_lane_state(workspace_root, run_state.run_id, lane)
 
-    if foreground:
-        if state.status == "paused_for_reflection":
+        if state.status == "evaluating":
+            typer.echo(
+                f"Lane {lane} is already evaluating (pid {state.eval_pid}); a "
+                "second concurrent `gepa lane continue` is rejected. If the "
+                f"eval is dead, run `gepa lane reset {lane}`.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        if state.status == "leased":
+            if foreground:
+                # The detached child consumes the handoff lease.
+                pass
+            else:
+                typer.echo(
+                    f"Lane {lane} is leased (epoch {state.lease_epoch}); a "
+                    "leased lane rejects a second `gepa lane continue` until "
+                    "the lease is consumed, reset, or expires.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+        if state.status not in {"paused_for_reflection", "leased", "stalled"}:
+            typer.echo(
+                f"Lane {lane} is {state.status}; `gepa lane continue` expects a "
+                "paused_for_reflection (or leased) lane.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        if not state.worktree_path or not state.branch:
+            typer.echo(
+                f"Lane {lane} has no worktree/branch recorded; run "
+                f"`gepa lane reset {lane}` to re-fan it.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        if not foreground:
+            # Handoff lease with a REAL expiry: if the detached child dies
+            # before its first heartbeat, the reaper can stall the lane.
+            handoff_expiry = now.timestamp() + run_state.eval_stall_timeout_secs
             state = LaneState(
                 **{
                     **state.to_dict(),
                     "status": "leased",
                     "lease_epoch": state.lease_epoch + 1,
+                    "lease_expires_at": datetime.fromtimestamp(
+                        handoff_expiry, timezone.utc
+                    ).isoformat(),
                     "updated_at": utc_now_iso(),
                 }
             )
             state.save(workspace_root, run_state.run_id)
+
+    if foreground:
         _run_lane_eval_loop(
             workspace_root=workspace_root, run_state=run_state, lane_state=state
         )
         return
 
     # Detached background eval: the child re-invokes this verb with
-    # --foreground, records its own pid, and refreshes the lane heartbeat.
+    # --foreground, consumes the handoff lease, records its own pid, and
+    # refreshes the lane heartbeat.
     gepa_abs = str(gepa_dir(workspace_root).resolve())
     lane_dir = lanes_dir(workspace_root, run_state.run_id) / lane
     lane_dir.mkdir(parents=True, exist_ok=True)
@@ -760,28 +882,31 @@ def lane_continue(
         "--foreground",
     ]
     worktree_path = str(state.worktree_path)
-    # Lease the lane for the eval; the detached child performs the
-    # leased -> evaluating transition itself (recording its pid) so a second
-    # `gepa lane continue` is rejected at every point in the handoff.
-    state = LaneState(
-        **{
-            **state.to_dict(),
-            "status": "leased",
-            "lease_epoch": state.lease_epoch + 1,
-            "lease_expires_at": None,
-            "updated_at": utc_now_iso(),
-        }
-    )
-    state.save(workspace_root, run_state.run_id)
-    with log_path.open("ab") as log_handle:
-        process = subprocess.Popen(  # noqa: S603
-            argv,
-            stdin=subprocess.DEVNULL,
-            stdout=log_handle,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            cwd=worktree_path,
-        )
+    try:
+        with log_path.open("ab") as log_handle:
+            process = subprocess.Popen(  # noqa: S603
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                cwd=worktree_path,
+            )
+    except OSError as exc:
+        # Spawn failed: release the handoff lease so the lane stays dispatchable.
+        with _lane_lock(workspace_root, run_state.run_id, lane):
+            current = load_lane_state(workspace_root, run_state.run_id, lane)
+            if current.status == "leased":
+                LaneState(
+                    **{
+                        **current.to_dict(),
+                        "status": "paused_for_reflection",
+                        "lease_expires_at": None,
+                        "updated_at": utc_now_iso(),
+                    }
+                ).save(workspace_root, run_state.run_id)
+        typer.echo(f"Failed to spawn lane eval: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     typer.echo(
         f"Lane {lane} eval detached (pid {process.pid}); log: {log_path}. "
         f"Watch `gepa next` for the verdict event."
@@ -796,51 +921,62 @@ def lane_reset(
     """Recover a stalled lane: terminate a dead/alive eval, reset to paused.
 
     A live recorded eval pid is terminated first (SIGTERM); uncommitted
-    worktree content is never auto-deleted.
+    worktree content is never auto-deleted. Lanes holding a resolved verdict
+    (awaiting_selection) cannot be reset — only `gepa run select` consumes
+    them, so a completed candidate is never destroyed unrecorded.
     """
     _validate_lane_id(lane)
     workspace_root, run_state = _resolve_lane_run(run_id)
-    state = load_lane_state(workspace_root, run_state.run_id, lane)
-    if state.eval_pid is not None and _pid_alive(state.eval_pid):
-        typer.echo(
-            f"Terminating lane {lane} eval process (pid {state.eval_pid}).",
-            err=True,
-        )
-        os.kill(state.eval_pid, signal.SIGTERM)
-        deadline = time.monotonic() + 5.0
-        while _pid_alive(state.eval_pid) and time.monotonic() < deadline:
-            time.sleep(0.05)
-        if _pid_alive(state.eval_pid):
+    with _lane_lock(workspace_root, run_state.run_id, lane):
+        state = load_lane_state(workspace_root, run_state.run_id, lane)
+        if state.status == "awaiting_selection":
             typer.echo(
-                f"Lane {lane} eval pid {state.eval_pid} did not exit after "
-                "SIGTERM; refusing to reset a live lane.",
+                f"Lane {lane} is awaiting_selection with verdict "
+                f"{state.verdict!r}; only `gepa run select` consumes it. "
+                "Refusing to reset (its outcome would be lost unrecorded).",
                 err=True,
             )
             raise typer.Exit(code=1)
-    worktree = Path(state.worktree_path) if state.worktree_path else None
-    if worktree is not None and worktree.exists():
-        dirty = _git(worktree, "status", "--porcelain")
-        if dirty:
+        if state.eval_pid is not None and _pid_alive(state.eval_pid):
             typer.echo(
-                f"Note: lane worktree {worktree} has uncommitted content; "
-                "it is preserved (never auto-deleted).",
+                f"Terminating lane {lane} eval process (pid {state.eval_pid}).",
                 err=True,
             )
-    state = LaneState(
-        **{
-            **state.to_dict(),
-            "status": "paused_for_reflection",
-            "lease_epoch": state.lease_epoch + 1,
-            "lease_expires_at": None,
-            "eval_pid": None,
-            "heartbeat_at": None,
-            "verdict": None,
-            "verdict_delta": None,
-            "eval_samples": (),
-            "updated_at": utc_now_iso(),
-        }
-    )
-    state.save(workspace_root, run_state.run_id)
+            os.kill(state.eval_pid, signal.SIGTERM)
+            deadline = time.monotonic() + 5.0
+            while _pid_alive(state.eval_pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            if _pid_alive(state.eval_pid):
+                typer.echo(
+                    f"Lane {lane} eval pid {state.eval_pid} did not exit after "
+                    "SIGTERM; refusing to reset a live lane.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+        worktree = Path(state.worktree_path) if state.worktree_path else None
+        if worktree is not None and worktree.exists():
+            dirty = _git(worktree, "status", "--porcelain")
+            if dirty:
+                typer.echo(
+                    f"Note: lane worktree {worktree} has uncommitted content; "
+                    "it is preserved (never auto-deleted).",
+                    err=True,
+                )
+        state = LaneState(
+            **{
+                **state.to_dict(),
+                "status": "paused_for_reflection",
+                "lease_epoch": state.lease_epoch + 1,
+                "lease_expires_at": None,
+                "eval_pid": None,
+                "heartbeat_at": None,
+                "verdict": None,
+                "verdict_delta": None,
+                "eval_samples": (),
+                "updated_at": utc_now_iso(),
+            }
+        )
+        state.save(workspace_root, run_state.run_id)
     typer.echo(
         f"Lane {lane} reset to paused_for_reflection (lease epoch "
         f"{state.lease_epoch}). Re-dispatch with the packet at "
@@ -876,12 +1012,14 @@ def scan_lane_states(workspace_root: Path, run_id: str, run_state: Any) -> LaneS
                 )
             else:
                 heartbeat_stale = True
+            # spec-1do: eval death is stale heartbeat PLUS dead pid — a stale
+            # heartbeat with a live pid is a slow eval, not a dead one (the
+            # documented response to lane_stalled is `lane reset`, which
+            # SIGTERMs the pid; false positives would kill healthy evals).
             if pid_dead:
                 stalled_reason = f"eval process pid {state.eval_pid} is dead"
-            elif heartbeat_stale:
-                stalled_reason = (
-                    f"eval heartbeat stale (>{run_state.eval_stall_timeout_secs:g}s)"
-                )
+                if heartbeat_stale:
+                    stalled_reason += " with a stale heartbeat"
         elif state.status == "leased":
             if state.lease_expires_at and _parse_iso(state.lease_expires_at) <= now:
                 stalled_reason = "reflection lease expired"
@@ -903,7 +1041,11 @@ def scan_lane_states(workspace_root: Path, run_id: str, run_state: Any) -> LaneS
 
     selection_due: SelectionDueSignal | None = None
     if resolved:
-        started = _parse_iso(run_state.updated_at)
+        # The straggler clock starts at fan-out/re-fan, not from
+        # run_state.updated_at — unrelated verb saves refresh that field and
+        # would otherwise starve the timeout indefinitely (spec-er3).
+        started_raw = run_state.iteration_started_at or run_state.updated_at
+        started = _parse_iso(started_raw)
         elapsed = (now - started).total_seconds()
         all_resolved = not stragglers
         if all_resolved or elapsed > run_state.straggler_timeout_secs:
@@ -916,9 +1058,33 @@ def scan_lane_states(workspace_root: Path, run_id: str, run_state: Any) -> LaneS
 
 
 def reaper_pass_for_run(workspace_root: Path, run_state: Any) -> list[str]:
-    """Run the lazy reaper with the real lane scanner for a lane run."""
+    """Run the lazy reaper with the real lane scanner for a lane run.
+
+    Stalled lanes are transitioned in state (dec-l95), not just reported on
+    the bus: the lane board shows `stalled`, and the status machine rows
+    leased/evaluating → stalled become reachable outside select.
+    """
     scan = scan_lane_states(workspace_root, run_state.run_id, run_state)
-    return run_reaper_pass(run_state.run_id, scan, root=workspace_root)
+    emitted = run_reaper_pass(run_state.run_id, scan, root=workspace_root)
+    for lane_scan in scan.lanes:
+        if lane_scan.stalled_reason is None:
+            continue
+        with _lane_lock(workspace_root, run_state.run_id, lane_scan.lane):
+            state = load_lane_state(workspace_root, run_state.run_id, lane_scan.lane)
+            if (
+                state.status in {"leased", "evaluating"}
+                and state.lease_epoch == lane_scan.lease_epoch
+            ):
+                LaneState(
+                    **{
+                        **state.to_dict(),
+                        "status": "stalled",
+                        "eval_pid": None,
+                        "lease_expires_at": None,
+                        "updated_at": utc_now_iso(),
+                    }
+                ).save(workspace_root, run_state.run_id)
+    return emitted
 
 
 # ----------------------------- fan-out (run start) ----------------------
@@ -930,6 +1096,10 @@ def fan_out_lanes(run_state: Any, workspace_root: Path) -> None:
     Called by `gepa run start --lanes N` after the shared baseline pause: all
     lanes branch from the frozen baseline commit (the run's best), so every
     lane in an iteration shares one branch point and one frozen baseline.
+
+    Fan-out failure is rolled back — worktrees, branches, lane states, and
+    lane_ready events created so far are removed — so a crash mid-fan-out
+    never leaves a zombie run (dec-jh6).
     """
     base_sha = run_state.reflection_baseline_commit_sha
     if not base_sha:
@@ -938,36 +1108,59 @@ def fan_out_lanes(run_state: Any, workspace_root: Path) -> None:
             err=True,
         )
         raise typer.Exit(code=1)
-    for lane in lane_ids(run_state.lanes):
-        path, branch = create_lane_worktree(
-            workspace_root, run_state.run_id, lane, run_state.iterations, base_sha
-        )
-        packet_path = write_packet(
-            workspace_root, run_state, lane, run_state.iterations, path, branch
-        )
-        LaneState(
-            lane=lane,
-            status="paused_for_reflection",
-            iteration=run_state.iterations,
-            branch=branch,
-            worktree_path=str(path),
-            packet_path=str(packet_path),
-            updated_at=utc_now_iso(),
-        ).save(workspace_root, run_state.run_id)
-        emit(
-            run_state.run_id,
-            "run",
-            EventDraft(
-                type="lane_ready",
+    created: list[tuple[Path, str, str]] = []  # (worktree path, branch, lane)
+    try:
+        for lane in lane_ids(run_state.lanes):
+            path, branch = create_lane_worktree(
+                workspace_root, run_state.run_id, lane, run_state.iterations, base_sha
+            )
+            created.append((path, branch, lane))
+            packet_path = write_packet(
+                workspace_root, run_state, lane, run_state.iterations, path, branch
+            )
+            LaneState(
                 lane=lane,
-                payload={
-                    "packet_path": str(packet_path),
-                    "worktree_path": str(path),
-                },
-            ),
-            root=workspace_root,
+                status="paused_for_reflection",
+                iteration=run_state.iterations,
+                branch=branch,
+                worktree_path=str(path),
+                packet_path=str(packet_path),
+                updated_at=utc_now_iso(),
+            ).save(workspace_root, run_state.run_id)
+            emit(
+                run_state.run_id,
+                "run",
+                EventDraft(
+                    type="lane_ready",
+                    lane=lane,
+                    payload={
+                        "packet_path": str(packet_path),
+                        "worktree_path": str(path),
+                    },
+                ),
+                root=workspace_root,
+            )
+            typer.echo(f"Lane {lane} ready: worktree {path}, packet {packet_path}.")
+    except Exception:
+        for path, branch, lane in reversed(created):
+            try:
+                _git(workspace_root, "worktree", "remove", "--force", str(path))
+            except Exception:
+                pass
+            try:
+                _git(workspace_root, "branch", "-D", branch)
+            except Exception:
+                pass
+            lane_dir = lanes_dir(workspace_root, run_state.run_id) / lane
+            if lane_dir.exists():
+                import shutil
+
+                shutil.rmtree(lane_dir, ignore_errors=True)
+        typer.echo(
+            "Lane fan-out failed; rolled back created worktrees/branches.",
+            err=True,
         )
-        typer.echo(f"Lane {lane} ready: worktree {path}, packet {packet_path}.")
+        raise
 
 
 def scan_run_lanes(run_id: str, root: Path | None = None) -> LaneScan | None:

--- a/src/pydantic_ai_gepa/cli/lanes.py
+++ b/src/pydantic_ai_gepa/cli/lanes.py
@@ -1,0 +1,984 @@
+"""Reflection lanes: worktree-backed candidate slots for managed runs.
+
+Implements pydanticaigepa-spec-1do. A lane is a git worktree plus a per-lane
+state slice under ``runs/<run_id>/lanes/<lane>/`` — the container for exactly
+one in-flight candidate, from branch-off through reflection, background
+evaluation, and verdict.
+
+Key contracts:
+
+- Lane processes locate the workspace explicitly — absolute ``--gepa-dir`` /
+  run id / lane id from packet fields or flags, ``GEPA_DIR`` env fallback; no
+  workspace path is derived from cwd (pydanticaigepa-dec-780).
+- ``gepa lane continue`` auto-commits all worktree changes onto
+  ``gepa/lane/<lane>/<iteration>`` before evaluating, so lane candidates are
+  always clean commits (pydanticaigepa-dec-tlz).
+- Lane evals run the repeated-evaluation acceptance policy as a detached
+  background process that records its pid and heartbeat in lane state and
+  emits a ``verdict`` event on resolution; budget checks are advisory per-eval
+  and enforced at select (pydanticaigepa-dec-msy).
+- Per-lane state is written only by that lane's own eval process or lifecycle
+  verbs — never by other lanes. Verdicts travel via the event stream and lane
+  state only; background evals never write shared run state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import typer
+
+from ..acceptance import compare_candidate_samples
+from .candidates import GitCandidateError, git_candidate_state
+from .eval import run_eval_once
+from .events import EventDraft, LaneScan, LaneScanResult, emit, run_reaper_pass
+from .layout import (
+    current_gepa_dirname,
+    gepa_dir,
+    repo_root,
+    run_dir,
+)
+from .runs import utc_now_iso
+
+LaneStatus = Literal[
+    "created",
+    "paused_for_reflection",
+    "leased",
+    "evaluating",
+    "awaiting_selection",
+    "stalled",
+]
+
+PACKET_VERSION = 1
+WORKTREES_DIRNAME = "worktrees"
+LANE_BRANCH_PREFIX = "gepa/lane"
+LANE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def lane_ids(count: int) -> list[str]:
+    """Canonical lane ids for a run started with ``--lanes count``."""
+    return [f"lane-{i}" for i in range(1, count + 1)]
+
+
+def lane_branch(lane: str, iteration: int) -> str:
+    return f"{LANE_BRANCH_PREFIX}/{lane}/{iteration}"
+
+
+# ----------------------------- workspace resolution ---------------------
+
+
+def _resolve_workspace_root() -> Path:
+    """Resolve the primary workspace root from the explicit gepa dir.
+
+    Lane processes are invoked with an absolute ``--gepa-dir`` (or the
+    ``GEPA_DIR`` env fallback), so the workspace root is the absolute
+    workspace's parent — never a directory walked up from cwd (dec-780).
+    """
+    dirname = current_gepa_dirname()
+    path = Path(dirname)
+    if not path.is_absolute():
+        raise typer.BadParameter(
+            "Lane verbs require an explicit absolute workspace: pass "
+            "`gepa --gepa-dir /abs/path/to/.gepa ...` or export GEPA_DIR. "
+            "No workspace path is derived from the current directory."
+        )
+    return path.resolve().parent
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    # Reap first when the process is our own child: a terminated child stays
+    # visible to kill(pid, 0) as a zombie until someone wait()s for it.
+    try:
+        reaped, _ = os.waitpid(pid, os.WNOHANG)
+        if reaped == pid:
+            return False
+    except ChildProcessError:
+        pass  # not our child — fall through to the kill probe
+    except OSError:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+# ----------------------------- per-lane state ---------------------------
+
+
+@dataclass(frozen=True)
+class LaneState:
+    """Per-lane state slice persisted at runs/<run_id>/lanes/<lane>/state.json.
+
+    Written only by the lane's own eval process or lifecycle verbs. Lanes have
+    no terminal state — a lane is re-fanned at select or removed when the run
+    completes.
+    """
+
+    lane: str
+    status: LaneStatus
+    iteration: int
+    branch: str | None = None
+    worktree_path: str | None = None
+    packet_path: str | None = None
+    lease_epoch: int = 0
+    lease_expires_at: str | None = None
+    candidate_sha: str | None = None
+    eval_samples: tuple[float, ...] = ()
+    verdict: str | None = None
+    verdict_delta: float | None = None
+    comparison_path: str | None = None
+    eval_pid: int | None = None
+    heartbeat_at: str | None = None
+    updated_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lane": self.lane,
+            "status": self.status,
+            "iteration": self.iteration,
+            "branch": self.branch,
+            "worktree_path": self.worktree_path,
+            "packet_path": self.packet_path,
+            "lease_epoch": self.lease_epoch,
+            "lease_expires_at": self.lease_expires_at,
+            "candidate_sha": self.candidate_sha,
+            "eval_samples": list(self.eval_samples),
+            "verdict": self.verdict,
+            "verdict_delta": self.verdict_delta,
+            "comparison_path": self.comparison_path,
+            "eval_pid": self.eval_pid,
+            "heartbeat_at": self.heartbeat_at,
+            "updated_at": self.updated_at,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> LaneState:
+        return LaneState(
+            lane=str(data["lane"]),
+            status=str(data["status"]),  # type: ignore[arg-type]
+            iteration=int(data["iteration"]),
+            branch=data.get("branch"),
+            worktree_path=data.get("worktree_path"),
+            packet_path=data.get("packet_path"),
+            lease_epoch=int(data.get("lease_epoch", 0)),
+            lease_expires_at=data.get("lease_expires_at"),
+            candidate_sha=data.get("candidate_sha"),
+            eval_samples=tuple(float(v) for v in data.get("eval_samples", [])),
+            verdict=data.get("verdict"),
+            verdict_delta=(
+                float(data["verdict_delta"])
+                if data.get("verdict_delta") is not None
+                else None
+            ),
+            comparison_path=data.get("comparison_path"),
+            eval_pid=(
+                int(data["eval_pid"]) if data.get("eval_pid") is not None else None
+            ),
+            heartbeat_at=data.get("heartbeat_at"),
+            updated_at=str(data.get("updated_at", "")),
+        )
+
+    def save(self, workspace_root: Path, run_id: str) -> Path:
+        path = lane_state_path(workspace_root, run_id, self.lane)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        return path
+
+
+def lanes_dir(workspace_root: Path, run_id: str) -> Path:
+    return run_dir(run_id, workspace_root) / "lanes"
+
+
+def lane_state_path(workspace_root: Path, run_id: str, lane: str) -> Path:
+    return lanes_dir(workspace_root, run_id) / lane / "state.json"
+
+
+def load_lane_state(workspace_root: Path, run_id: str, lane: str) -> LaneState:
+    path = lane_state_path(workspace_root, run_id, lane)
+    if not path.exists():
+        raise typer.BadParameter(
+            f"No lane state at {path}. Was this run started with --lanes?"
+        )
+    return LaneState.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def load_all_lane_states(workspace_root: Path, run_id: str) -> list[LaneState]:
+    base = lanes_dir(workspace_root, run_id)
+    if not base.is_dir():
+        return []
+    states: list[LaneState] = []
+    for entry in sorted(base.iterdir()):
+        state_path = entry / "state.json"
+        if state_path.exists():
+            states.append(
+                LaneState.from_dict(json.loads(state_path.read_text(encoding="utf-8")))
+            )
+    return states
+
+
+# ----------------------------- worktrees --------------------------------
+
+
+def worktrees_root(workspace_root: Path) -> Path:
+    return workspace_root / WORKTREES_DIRNAME
+
+
+def lane_worktree_path(workspace_root: Path, lane: str) -> Path:
+    return worktrees_root(workspace_root) / lane
+
+
+def ensure_worktrees_ignored(workspace_root: Path) -> None:
+    """Gitignore the worktrees dir via .git/info/exclude (never tracked files).
+
+    Adding to .gitignore would dirty the primary tree; info/exclude is local
+    and untracked, so `git ls-files --others --exclude-standard` (used by git
+    candidate identity) skips lane worktrees automatically.
+    """
+    info_dir = workspace_root / ".git" / "info"
+    info_dir.mkdir(parents=True, exist_ok=True)
+    exclude = info_dir / "exclude"
+    entry = f"/{WORKTREES_DIRNAME}/"
+    existing = exclude.read_text(encoding="utf-8") if exclude.exists() else ""
+    if entry not in existing.splitlines():
+        with exclude.open("a", encoding="utf-8") as fh:
+            fh.write(f"{entry}\n")
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def create_lane_worktree(
+    workspace_root: Path, run_id: str, lane: str, iteration: int, base_sha: str
+) -> tuple[Path, str]:
+    """Create the lane worktree + branch cut from ``base_sha`` (the run's best)."""
+    branch = lane_branch(lane, iteration)
+    path = lane_worktree_path(workspace_root, lane)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(workspace_root, "worktree", "add", str(path), "-b", branch, base_sha)
+    return path, branch
+
+
+# ----------------------------- packet -----------------------------------
+
+
+def _journal_tail(workspace_root: Path, limit: int) -> list[dict[str, Any]]:
+    """Bounded journal tail for the reflection packet (workspace-explicit)."""
+    from .layout import journal_path
+
+    path = journal_path(workspace_root)
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped:
+            rows.append(json.loads(stripped))
+    return rows[-limit:] if limit > 0 else rows
+
+
+def _collect_metric_side_info(trace_paths: list[str]) -> dict[str, Any]:
+    """Collect per-case metric side info from baseline trace files."""
+    side_info: dict[str, Any] = {}
+    for raw in trace_paths:
+        path = Path(raw)
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            record = json.loads(stripped)
+            info = record.get("metric_side_info")
+            if info and record.get("case_id"):
+                side_info[str(record["case_id"])] = info
+    return side_info
+
+
+def write_packet(
+    workspace_root: Path,
+    run_state: Any,  # RunState — imported lazily to avoid a module cycle
+    lane: str,
+    iteration: int,
+    worktree_path: Path,
+    branch: str,
+) -> Path:
+    """Write the versioned reflection packet for a paused lane.
+
+    A subagent needs only the packet path to work: baseline samples with
+    report/trace paths, metric side info, a bounded journal tail, the worktree
+    path, and the exact `gepa lane continue` invocation.
+    """
+    gepa_abs = str(gepa_dir(workspace_root).resolve())
+    invocation = (
+        f"gepa --gepa-dir {shlex.quote(gepa_abs)} "
+        f"lane continue {shlex.quote(lane)} --run-id {shlex.quote(run_state.run_id)}"
+    )
+    packet = {
+        "packet_version": PACKET_VERSION,
+        "run_id": run_state.run_id,
+        "lane": lane,
+        "iteration": iteration,
+        "worktree_path": str(worktree_path),
+        "branch": branch,
+        "baseline": {
+            "candidate_id": run_state.reflection_baseline_candidate_id,
+            "commit_sha": run_state.reflection_baseline_commit_sha,
+            "mean_score": run_state.reflection_baseline_mean_score,
+            "samples": list(run_state.reflection_baseline_samples),
+            "minibatch_id": run_state.reflection_minibatch_id,
+            "report_paths": list(run_state.reflection_baseline_report_paths),
+            "trace_paths": list(run_state.reflection_baseline_trace_paths),
+        },
+        "metric_side_info": _collect_metric_side_info(
+            list(run_state.reflection_baseline_trace_paths)
+        ),
+        "journal_tail": _journal_tail(workspace_root, run_state.journal_tail_lines),
+        "continue_invocation": invocation,
+    }
+    path = lanes_dir(workspace_root, run_state.run_id) / lane / "packet.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(packet, indent=2, default=str), encoding="utf-8")
+    return path
+
+
+# ----------------------------- lane eval --------------------------------
+
+
+def _auto_commit_worktree(worktree: Path, branch: str, lane: str) -> str:
+    """Commit all worktree changes onto the lane branch; return the HEAD sha.
+
+    Lane candidates are always clean commits because continue auto-commits
+    (dec-tlz).
+    """
+    _git(worktree, "add", "-A")
+    status = _git(worktree, "status", "--porcelain")
+    if status:
+        _git(
+            worktree,
+            "-c",
+            "user.name=gepa-lane",
+            "-c",
+            "user.email=gepa-lane@localhost",
+            "commit",
+            "-m",
+            f"gepa lane continue: {lane} candidate",
+        )
+    current_branch = _git(worktree, "rev-parse", "--abbrev-ref", "HEAD")
+    if current_branch != branch:
+        raise typer.BadParameter(
+            f"Lane worktree {worktree} is on branch {current_branch!r}, "
+            f"expected {branch!r}; run `gepa lane reset {lane}` to recover."
+        )
+    return _git(worktree, "rev-parse", "HEAD")
+
+
+def _write_comparison(
+    workspace_root: Path,
+    run_id: str,
+    lane: str,
+    iteration: int,
+    comparison: dict[str, Any],
+) -> Path:
+    path = lanes_dir(workspace_root, run_id) / lane / f"comparison-{iteration:04d}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(comparison, indent=2, default=str), encoding="utf-8")
+    return path
+
+
+def _touch_heartbeat(
+    workspace_root: Path, run_id: str, state: LaneState, pid: int
+) -> LaneState:
+    fresh = LaneState(
+        **{
+            **state.to_dict(),
+            "heartbeat_at": utc_now_iso(),
+            "eval_pid": pid,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    fresh.save(workspace_root, run_id)
+    return fresh
+
+
+def _run_lane_eval_loop(
+    *,
+    workspace_root: Path,
+    run_state: Any,  # RunState
+    lane_state: LaneState,
+) -> LaneState:
+    """Run the escalating acceptance eval for the lane's committed candidate.
+
+    Mirrors the single-path ``_evaluate_reflected_candidate`` escalation
+    (repeated evals against the frozen reflection minibatch, early stop once
+    the comparison resolves), writing progress into lane state and emitting a
+    ``verdict`` event on resolution. Never writes shared run state.
+    """
+    run_id = run_state.run_id
+    lane = lane_state.lane
+    if run_state.reflection_minibatch_id is None:
+        raise typer.BadParameter(
+            f"Run {run_id} has no reflection minibatch; cannot evaluate lane."
+        )
+    if not run_state.reflection_baseline_samples:
+        raise typer.BadParameter(
+            f"Run {run_id} is missing reflection baseline samples."
+        )
+
+    worktree = Path(str(lane_state.worktree_path))
+    branch = str(lane_state.branch)
+    commit_sha = _auto_commit_worktree(worktree, branch, lane)
+
+    try:
+        git_state = git_candidate_state(worktree)
+    except GitCandidateError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    if git_state.dirty:
+        raise typer.BadParameter(
+            f"Lane worktree {worktree} is still dirty after auto-commit; "
+            "refusing to evaluate an unstable candidate."
+        )
+
+    pid = os.getpid()
+    lane_state = LaneState(
+        **{
+            **lane_state.to_dict(),
+            "status": "evaluating",
+            "candidate_sha": commit_sha,
+            "eval_samples": (),
+            "verdict": None,
+            "verdict_delta": None,
+            "comparison_path": None,
+        }
+    )
+    lane_state = _touch_heartbeat(workspace_root, run_id, lane_state, pid)
+
+    baseline_samples = tuple(float(v) for v in run_state.reflection_baseline_samples)
+    max_candidate_samples = len(baseline_samples)
+    initial_samples = min(run_state.acceptance_repetitions, max_candidate_samples)
+
+    samples: list[float] = []
+    outcomes: list[Any] = []
+    comparison_result = None
+    for _ in range(max_candidate_samples):
+        outcome = run_eval_once(
+            candidate_file=None,
+            minibatch_id=run_state.reflection_minibatch_id,
+            size=run_state.size,
+            seed=run_state.seed,
+            epoch=run_state.next_epoch,
+            run_id=run_id,
+            concurrency=run_state.concurrency,
+            max_iterations=run_state.max_iterations,
+            threshold=run_state.threshold,
+            capture_traces=True,
+            candidate_source="git",
+            lane=lane,
+            candidate_root=worktree,
+            workspace_root=workspace_root,
+        )
+        outcomes.append(outcome)
+        current_id = str(outcome.summary["candidate_id"])
+        if current_id != git_state.candidate_id:
+            raise typer.BadParameter(
+                "The lane candidate changed mid-evaluation "
+                f"({git_state.candidate_id} -> {current_id}); refusing to "
+                "compare mixed candidates."
+            )
+        samples.append(float(outcome.summary["mean_score"]))
+        lane_state = LaneState(
+            **{**lane_state.to_dict(), "eval_samples": tuple(samples)}
+        )
+        lane_state = _touch_heartbeat(workspace_root, run_id, lane_state, pid)
+
+        if len(samples) < initial_samples:
+            continue
+        comparison_result = compare_candidate_samples(
+            baseline_samples[: len(samples)],
+            tuple(samples),
+            confidence=run_state.acceptance_confidence,
+            min_delta=run_state.acceptance_min_delta,
+        )
+        if comparison_result.verdict != "inconclusive":
+            break
+
+    assert comparison_result is not None
+    comparison = {
+        "run_id": run_id,
+        "lane": lane,
+        "iteration": lane_state.iteration,
+        "minibatch_id": run_state.reflection_minibatch_id,
+        "baseline_candidate_id": run_state.reflection_baseline_candidate_id,
+        "baseline_commit_sha": run_state.reflection_baseline_commit_sha,
+        "candidate_id": git_state.candidate_id,
+        "candidate_commit_sha": commit_sha,
+        "candidate_report_paths": [
+            outcome.summary["report_path"] for outcome in outcomes
+        ],
+        "candidate_trace_paths": [
+            outcome.summary["trace_path"]
+            for outcome in outcomes
+            if outcome.summary.get("trace_path")
+        ],
+        **comparison_result.to_dict(),
+    }
+    comparison_path = _write_comparison(
+        workspace_root, run_id, lane, lane_state.iteration, comparison
+    )
+    verdict_id = emit(
+        run_id,
+        lane,
+        EventDraft(
+            type="verdict",
+            lane=lane,
+            payload={
+                "verdict": comparison_result.verdict,
+                "delta": comparison_result.delta,
+                "comparison_path": str(comparison_path),
+            },
+        ),
+        root=workspace_root,
+    )
+    lane_state = LaneState(
+        **{
+            **lane_state.to_dict(),
+            "status": "awaiting_selection",
+            "verdict": comparison_result.verdict,
+            "verdict_delta": comparison_result.delta,
+            "comparison_path": str(comparison_path),
+            "eval_pid": None,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    lane_state.save(workspace_root, run_id)
+    typer.echo(
+        f"Lane {lane} verdict: {comparison_result.verdict} "
+        f"(delta={comparison_result.delta:+.4f}); event {verdict_id}."
+    )
+    return lane_state
+
+
+# ----------------------------- verbs ------------------------------------
+
+app = typer.Typer(
+    no_args_is_help=True,
+    help="Drive reflection lanes: lease, continue (background eval), reset.",
+)
+
+
+def _load_run_state(workspace_root: Path, run_id: str) -> Any:
+    from .run import RunState  # local import: run.py imports lanes lazily
+
+    path = run_dir(run_id, workspace_root) / "state.json"
+    if not path.exists():
+        typer.echo(
+            f"No managed run state at {path}. Start one with `gepa run start`.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return RunState.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _resolve_lane_run(run_id: str | None) -> tuple[Path, Any]:
+    """Resolve (workspace_root, RunState) explicitly; reject non-lane runs."""
+    workspace_root = _resolve_workspace_root()
+    if run_id is None:
+        from .layout import latest_run_id
+
+        run_id = latest_run_id(workspace_root)
+        if run_id is None:
+            typer.echo("No runs found. Start one with `gepa run start`.", err=True)
+            raise typer.Exit(code=1)
+    run_state = _load_run_state(workspace_root, run_id)
+    if run_state.lanes < 1:
+        typer.echo(
+            f"Run {run_state.run_id} is not a lane run (started without --lanes); "
+            "lane verbs do not apply.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return workspace_root, run_state
+
+
+def _validate_lane_id(lane: str) -> str:
+    if not LANE_ID_RE.match(lane):
+        raise typer.BadParameter(f"Invalid lane id {lane!r}.")
+    return lane
+
+
+@app.command("lease")
+def lane_lease(
+    lane: str = typer.Argument(..., help="Lane id (e.g. lane-1)."),
+    run_id: str | None = typer.Option(None, "--run-id", help="Defaults to latest run."),
+) -> None:
+    """Record a dispatch lease on a paused lane.
+
+    The orchestrator leases a lane before dispatching a reflector subagent.
+    A leased lane rejects re-dispatch and a second concurrent
+    `gepa lane continue` until the lease is released or times out.
+    """
+    _validate_lane_id(lane)
+    workspace_root, run_state = _resolve_lane_run(run_id)
+    state = load_lane_state(workspace_root, run_state.run_id, lane)
+    now = datetime.now(timezone.utc)
+    if state.status == "leased" and state.lease_expires_at:
+        if _parse_iso(state.lease_expires_at) > now:
+            typer.echo(
+                f"Lane {lane} is already leased until {state.lease_expires_at} "
+                f"(lease epoch {state.lease_epoch}); refusing re-dispatch.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+    if state.status not in {"paused_for_reflection", "leased"}:
+        typer.echo(
+            f"Lane {lane} is {state.status}; only paused_for_reflection lanes "
+            "can be leased for dispatch.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    expires = now.timestamp() + run_state.reflection_lease_secs
+    expires_at = datetime.fromtimestamp(expires, timezone.utc).isoformat()
+    state = LaneState(
+        **{
+            **state.to_dict(),
+            "status": "leased",
+            "lease_epoch": state.lease_epoch + 1,
+            "lease_expires_at": expires_at,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    state.save(workspace_root, run_state.run_id)
+    typer.echo(
+        f"Lane {lane} leased (epoch {state.lease_epoch}, expires {expires_at}). "
+        f"Dispatch a reflector with the packet at {state.packet_path}."
+    )
+
+
+@app.command("continue")
+def lane_continue(
+    lane: str = typer.Argument(..., help="Lane id (e.g. lane-1)."),
+    run_id: str | None = typer.Option(None, "--run-id", help="Defaults to latest run."),
+    foreground: bool = typer.Option(
+        False,
+        "--foreground",
+        help="Run the acceptance eval in-process instead of detaching (used by the detached wrapper and by tests).",
+    ),
+) -> None:
+    """Auto-commit the lane worktree and evaluate the candidate in the background.
+
+    Resolves the workspace explicitly from --gepa-dir / GEPA_DIR (never cwd),
+    commits all worktree changes onto the lane branch, then runs the
+    repeated-evaluation acceptance policy as a detached process that streams
+    progress + heartbeat into lane state and emits a `verdict` event on
+    resolution.
+    """
+    _validate_lane_id(lane)
+    workspace_root, run_state = _resolve_lane_run(run_id)
+    state = load_lane_state(workspace_root, run_state.run_id, lane)
+
+    if state.status == "evaluating":
+        typer.echo(
+            f"Lane {lane} is already evaluating (pid {state.eval_pid}); a "
+            "leased/evaluating lane rejects a second concurrent "
+            "`gepa lane continue`.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if state.status not in {"paused_for_reflection", "leased", "stalled"}:
+        typer.echo(
+            f"Lane {lane} is {state.status}; `gepa lane continue` expects a "
+            "paused_for_reflection (or leased) lane.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if not state.worktree_path or not state.branch:
+        typer.echo(
+            f"Lane {lane} has no worktree/branch recorded; run "
+            f"`gepa lane reset {lane}` to re-fan it.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if foreground:
+        if state.status == "paused_for_reflection":
+            state = LaneState(
+                **{
+                    **state.to_dict(),
+                    "status": "leased",
+                    "lease_epoch": state.lease_epoch + 1,
+                    "updated_at": utc_now_iso(),
+                }
+            )
+            state.save(workspace_root, run_state.run_id)
+        _run_lane_eval_loop(
+            workspace_root=workspace_root, run_state=run_state, lane_state=state
+        )
+        return
+
+    # Detached background eval: the child re-invokes this verb with
+    # --foreground, records its own pid, and refreshes the lane heartbeat.
+    gepa_abs = str(gepa_dir(workspace_root).resolve())
+    lane_dir = lanes_dir(workspace_root, run_state.run_id) / lane
+    lane_dir.mkdir(parents=True, exist_ok=True)
+    log_path = lane_dir / "eval.log"
+    argv = [
+        sys.executable,
+        "-c",
+        "from pydantic_ai_gepa.cli import app; app()",
+        "--gepa-dir",
+        gepa_abs,
+        "lane",
+        "continue",
+        lane,
+        "--run-id",
+        run_state.run_id,
+        "--foreground",
+    ]
+    worktree_path = str(state.worktree_path)
+    # Lease the lane for the eval; the detached child performs the
+    # leased -> evaluating transition itself (recording its pid) so a second
+    # `gepa lane continue` is rejected at every point in the handoff.
+    state = LaneState(
+        **{
+            **state.to_dict(),
+            "status": "leased",
+            "lease_epoch": state.lease_epoch + 1,
+            "lease_expires_at": None,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    state.save(workspace_root, run_state.run_id)
+    with log_path.open("ab") as log_handle:
+        process = subprocess.Popen(  # noqa: S603
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            cwd=worktree_path,
+        )
+    typer.echo(
+        f"Lane {lane} eval detached (pid {process.pid}); log: {log_path}. "
+        f"Watch `gepa next` for the verdict event."
+    )
+
+
+@app.command("reset")
+def lane_reset(
+    lane: str = typer.Argument(..., help="Lane id (e.g. lane-1)."),
+    run_id: str | None = typer.Option(None, "--run-id", help="Defaults to latest run."),
+) -> None:
+    """Recover a stalled lane: terminate a dead/alive eval, reset to paused.
+
+    A live recorded eval pid is terminated first (SIGTERM); uncommitted
+    worktree content is never auto-deleted.
+    """
+    _validate_lane_id(lane)
+    workspace_root, run_state = _resolve_lane_run(run_id)
+    state = load_lane_state(workspace_root, run_state.run_id, lane)
+    if state.eval_pid is not None and _pid_alive(state.eval_pid):
+        typer.echo(
+            f"Terminating lane {lane} eval process (pid {state.eval_pid}).",
+            err=True,
+        )
+        os.kill(state.eval_pid, signal.SIGTERM)
+        deadline = time.monotonic() + 5.0
+        while _pid_alive(state.eval_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        if _pid_alive(state.eval_pid):
+            typer.echo(
+                f"Lane {lane} eval pid {state.eval_pid} did not exit after "
+                "SIGTERM; refusing to reset a live lane.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+    worktree = Path(state.worktree_path) if state.worktree_path else None
+    if worktree is not None and worktree.exists():
+        dirty = _git(worktree, "status", "--porcelain")
+        if dirty:
+            typer.echo(
+                f"Note: lane worktree {worktree} has uncommitted content; "
+                "it is preserved (never auto-deleted).",
+                err=True,
+            )
+    state = LaneState(
+        **{
+            **state.to_dict(),
+            "status": "paused_for_reflection",
+            "lease_epoch": state.lease_epoch + 1,
+            "lease_expires_at": None,
+            "eval_pid": None,
+            "heartbeat_at": None,
+            "verdict": None,
+            "verdict_delta": None,
+            "eval_samples": (),
+            "updated_at": utc_now_iso(),
+        }
+    )
+    state.save(workspace_root, run_state.run_id)
+    typer.echo(
+        f"Lane {lane} reset to paused_for_reflection (lease epoch "
+        f"{state.lease_epoch}). Re-dispatch with the packet at "
+        f"{state.packet_path}."
+    )
+
+
+# ----------------------------- reaper scanner ---------------------------
+
+
+def scan_lane_states(workspace_root: Path, run_id: str, run_state: Any) -> LaneScan:
+    """Scan lane leases, heartbeat freshness, and recorded pids (dec-pm3).
+
+    This is the real scanner behind the event bus's lazy reaper: a lane is
+    stalled when its eval pid is dead, its heartbeat is stale, or its
+    reflection lease expired. ``selection_due`` signals when every lane is
+    resolved (awaiting_selection) or the straggler timeout has elapsed with
+    at least one resolved lane.
+    """
+    now = datetime.now(timezone.utc)
+    results: list[LaneScanResult] = []
+    resolved: list[str] = []
+    stragglers: list[str] = []
+    for state in load_all_lane_states(workspace_root, run_id):
+        stalled_reason: str | None = None
+        if state.status == "evaluating":
+            pid_dead = state.eval_pid is not None and not _pid_alive(state.eval_pid)
+            heartbeat_stale = False
+            if state.heartbeat_at:
+                age = now - _parse_iso(state.heartbeat_at)
+                heartbeat_stale = (
+                    age.total_seconds() > run_state.eval_stall_timeout_secs
+                )
+            else:
+                heartbeat_stale = True
+            if pid_dead:
+                stalled_reason = f"eval process pid {state.eval_pid} is dead"
+            elif heartbeat_stale:
+                stalled_reason = (
+                    f"eval heartbeat stale (>{run_state.eval_stall_timeout_secs:g}s)"
+                )
+        elif state.status == "leased":
+            if state.lease_expires_at and _parse_iso(state.lease_expires_at) <= now:
+                stalled_reason = "reflection lease expired"
+        if stalled_reason is not None:
+            results.append(
+                LaneScanResult(
+                    lane=state.lane,
+                    lease_epoch=state.lease_epoch,
+                    stalled_reason=stalled_reason,
+                )
+            )
+            stragglers.append(state.lane)
+        elif state.status == "awaiting_selection":
+            resolved.append(state.lane)
+        else:
+            stragglers.append(state.lane)
+
+    from .events import SelectionDueSignal
+
+    selection_due: SelectionDueSignal | None = None
+    if resolved:
+        started = _parse_iso(run_state.updated_at)
+        elapsed = (now - started).total_seconds()
+        all_resolved = not stragglers
+        if all_resolved or elapsed > run_state.straggler_timeout_secs:
+            selection_due = SelectionDueSignal(
+                iteration=run_state.iterations,
+                resolved_lanes=tuple(resolved),
+                straggler_lanes=tuple(stragglers),
+            )
+    return LaneScan(lanes=tuple(results), selection_due=selection_due)
+
+
+def reaper_pass_for_run(workspace_root: Path, run_state: Any) -> list[str]:
+    """Run the lazy reaper with the real lane scanner for a lane run."""
+    scan = scan_lane_states(workspace_root, run_state.run_id, run_state)
+    return run_reaper_pass(run_state.run_id, scan, root=workspace_root)
+
+
+# ----------------------------- fan-out (run start) ----------------------
+
+
+def fan_out_lanes(run_state: Any, workspace_root: Path) -> None:
+    """Create worktrees, write packets, and emit lane_ready for every lane.
+
+    Called by `gepa run start --lanes N` after the shared baseline pause: all
+    lanes branch from the frozen baseline commit (the run's best), so every
+    lane in an iteration shares one branch point and one frozen baseline.
+    """
+    base_sha = run_state.reflection_baseline_commit_sha
+    if not base_sha:
+        typer.echo(
+            "Cannot fan out lanes: the run has no reflection baseline commit.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    for lane in lane_ids(run_state.lanes):
+        path, branch = create_lane_worktree(
+            workspace_root, run_state.run_id, lane, run_state.iterations, base_sha
+        )
+        packet_path = write_packet(
+            workspace_root, run_state, lane, run_state.iterations, path, branch
+        )
+        LaneState(
+            lane=lane,
+            status="paused_for_reflection",
+            iteration=run_state.iterations,
+            branch=branch,
+            worktree_path=str(path),
+            packet_path=str(packet_path),
+            updated_at=utc_now_iso(),
+        ).save(workspace_root, run_state.run_id)
+        emit(
+            run_state.run_id,
+            "run",
+            EventDraft(
+                type="lane_ready",
+                lane=lane,
+                payload={
+                    "packet_path": str(packet_path),
+                    "worktree_path": str(path),
+                },
+            ),
+            root=workspace_root,
+        )
+        typer.echo(f"Lane {lane} ready: worktree {path}, packet {packet_path}.")
+
+
+def scan_run_lanes(run_id: str, root: Path | None = None) -> LaneScan | None:
+    """Real scanner behind events.scan_lanes: None when this is not a lane run."""
+    workspace_root = (root or repo_root()).resolve()
+    state_path = run_dir(run_id, workspace_root) / "state.json"
+    if not state_path.exists():
+        return None
+    from .run import RunState  # lazy: run.py imports lanes lazily
+
+    run_state = RunState.from_dict(json.loads(state_path.read_text(encoding="utf-8")))
+    if run_state.lanes < 1:
+        return None
+    return scan_lane_states(workspace_root, run_id, run_state)

--- a/src/pydantic_ai_gepa/cli/run.py
+++ b/src/pydantic_ai_gepa/cli/run.py
@@ -30,6 +30,7 @@ from .layout import (
     final_report_path,
     insert_repo_root_on_path,
     new_run_id,
+    repo_root,
     resolve_agent,
     resolve_skills,
     run_dir,
@@ -90,6 +91,14 @@ class RunState:
     best_candidate_id: str | None = None
     best_commit_sha: str | None = None
     best_mean_score: float | None = None
+    # Lane-run fields (spec-1do). All defaulted so run state files written
+    # before lanes existed load unchanged.
+    lanes: int = 0
+    heartbeat_interval_secs: float = 10.0
+    reflection_lease_secs: float = 1800.0
+    eval_stall_timeout_secs: float = 600.0
+    straggler_timeout_secs: float = 900.0
+    journal_tail_lines: int = 20
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -132,6 +141,12 @@ class RunState:
             "best_candidate_id": self.best_candidate_id,
             "best_commit_sha": self.best_commit_sha,
             "best_mean_score": self.best_mean_score,
+            "lanes": self.lanes,
+            "heartbeat_interval_secs": self.heartbeat_interval_secs,
+            "reflection_lease_secs": self.reflection_lease_secs,
+            "eval_stall_timeout_secs": self.eval_stall_timeout_secs,
+            "straggler_timeout_secs": self.straggler_timeout_secs,
+            "journal_tail_lines": self.journal_tail_lines,
         }
 
     @staticmethod
@@ -231,6 +246,12 @@ class RunState:
                 if data.get("best_mean_score") is not None
                 else None
             ),
+            lanes=int(data.get("lanes", 0)),
+            heartbeat_interval_secs=float(data.get("heartbeat_interval_secs", 10.0)),
+            reflection_lease_secs=float(data.get("reflection_lease_secs", 1800.0)),
+            eval_stall_timeout_secs=float(data.get("eval_stall_timeout_secs", 600.0)),
+            straggler_timeout_secs=float(data.get("straggler_timeout_secs", 900.0)),
+            journal_tail_lines=int(data.get("journal_tail_lines", 20)),
         )
 
     def save(self) -> Path:
@@ -688,9 +709,12 @@ def _public_state(
     payload = state.to_dict()
     payload["state_path"] = str(run_state_path(state.run_id))
     payload["final_report_path"] = str(final_report) if final_report else None
-    payload["next_command"] = (
-        None if state.status == "done" else f"gepa run continue --run-id {state.run_id}"
-    )
+    if state.status == "done":
+        payload["next_command"] = None
+    elif state.lanes > 0:
+        payload["next_command"] = f"gepa next --wait --run-id {state.run_id}"
+    else:
+        payload["next_command"] = f"gepa run continue --run-id {state.run_id}"
     payload["evaluations_this_call"] = [outcome.summary for outcome in outcomes]
     return payload
 
@@ -850,9 +874,42 @@ def start(
         "--candidate-source",
         help="Override gepa.toml candidate_source for this run: components or git.",
     ),
+    lanes: int = typer.Option(
+        0,
+        "--lanes",
+        help="Number of parallel reflection lanes (git candidate mode only). 0 keeps the synchronous single-path loop.",
+    ),
+    heartbeat_interval_secs: float = typer.Option(
+        10.0,
+        "--heartbeat-interval-secs",
+        help="Lane runs: heartbeat refresh interval for background lane evals.",
+    ),
+    reflection_lease_secs: float = typer.Option(
+        1800.0,
+        "--reflection-lease-secs",
+        help="Lane runs: dispatch lease expiry; a leased lane that never reaches `gepa lane continue` is stalled after this.",
+    ),
+    eval_stall_timeout_secs: float = typer.Option(
+        600.0,
+        "--eval-stall-timeout-secs",
+        help="Lane runs: a lane eval whose heartbeat is older than this (with a dead pid) is stalled.",
+    ),
+    straggler_timeout_secs: float = typer.Option(
+        900.0,
+        "--straggler-timeout-secs",
+        help="Lane runs: selection fires once every lane resolves or this timeout elapses.",
+    ),
+    journal_tail_lines: int = typer.Option(
+        20,
+        "--journal-tail-lines",
+        help="Lane runs: how many journal entries each reflection packet carries.",
+    ),
 ) -> None:
     """Start a managed GEPA run and pause at the first reflection point."""
     _validate_max_iterations(max_iterations)
+    if lanes < 0:
+        typer.echo("--lanes must be >= 0.", err=True)
+        raise typer.Exit(code=2)
     resolved_max_repetitions = (
         acceptance_repetitions
         if acceptance_max_repetitions is None
@@ -871,6 +928,39 @@ def start(
     active_candidate_source = cast(
         CandidateSource, candidate_source or cfg.candidate_source
     )
+    if lanes > 0:
+        if active_candidate_source != "git":
+            typer.echo(
+                "--lanes requires git candidate mode (component-mode lanes share "
+                "one process-global agent and are out of scope, spec-1do).",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        # Lane branches are always cut from a clean commit; a dirty primary
+        # tree is rejected (spec-1do constraint).
+        from .lanes import ensure_worktrees_ignored, worktrees_root
+
+        workspace_root = repo_root()
+        ensure_worktrees_ignored(workspace_root)
+        try:
+            primary_state = git_candidate_state(
+                workspace_root,
+                exclude_paths=[
+                    runs_dir(workspace_root),
+                    worktrees_root(workspace_root),
+                ],
+            )
+        except GitCandidateError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
+        if primary_state.dirty:
+            typer.echo(
+                "`gepa run start --lanes` requires a clean primary tree; "
+                "commit or stash your changes first (lane branches are cut "
+                "from a clean commit).",
+                err=True,
+            )
+            raise typer.Exit(code=1)
     run_id = new_run_id()
     run_dir(run_id).mkdir(parents=True, exist_ok=True)
     now = utc_now_iso()
@@ -891,10 +981,24 @@ def start(
         iterations=0,
         created_at=now,
         updated_at=now,
+        lanes=lanes,
+        heartbeat_interval_secs=heartbeat_interval_secs,
+        reflection_lease_secs=reflection_lease_secs,
+        eval_stall_timeout_secs=eval_stall_timeout_secs,
+        straggler_timeout_secs=straggler_timeout_secs,
+        journal_tail_lines=journal_tail_lines,
     )
     state.save()
     state, outcomes = _advance_to_reflection_or_done(state)
     state.save()
+    if lanes > 0 and state.status == "paused_for_reflection":
+        # Fan out: worktrees + packets + lane_ready events. The run-level
+        # status returns to "running" — lanes carry the reflection pause.
+        from .lanes import fan_out_lanes
+
+        fan_out_lanes(state, repo_root())
+        state = _with_timestamp(state, status="running")
+        state.save()
 
     final_path: Path | None = None
     final_text: str | None = None
@@ -915,6 +1019,14 @@ def continue_(
 ) -> None:
     """Resume after reflection edits and advance to the next pause or completion."""
     state = _load_state(run_id)
+    if state.lanes > 0:
+        typer.echo(
+            "`gepa run continue` does not drive lane runs. Evaluate a lane with "
+            "`gepa lane continue <lane>` and commit the iteration with "
+            "`gepa run select`.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     if state.status == "done":
         final_path, final_text = _write_final_report(state)
         _emit_status(
@@ -987,12 +1099,23 @@ def status(
         help="Managed run id. Omit to use the latest run with a state file.",
     ),
 ) -> None:
-    """Print the managed run state as JSON."""
+    """Print the managed run state as JSON (lane runs include the lane board)."""
     state = _load_state(run_id)
     final_path = final_report_path(state.run_id) if state.status == "done" else None
-    typer.echo(
-        json.dumps({"run": _public_state(state, outcomes=[], final_report=final_path)})
-    )
+    payload: dict[str, Any] = {
+        "run": _public_state(state, outcomes=[], final_report=final_path)
+    }
+    if state.lanes > 0:
+        # Consumer verbs run the lazy reaper first (dec-pm3).
+        from .lanes import load_all_lane_states, reaper_pass_for_run
+
+        workspace_root = repo_root()
+        reaper_pass_for_run(workspace_root, state)
+        payload["lanes"] = [
+            lane_state.to_dict()
+            for lane_state in load_all_lane_states(workspace_root, state.run_id)
+        ]
+    typer.echo(json.dumps(payload))
 
 
 __all__ = ["app"]

--- a/src/pydantic_ai_gepa/cli/run.py
+++ b/src/pydantic_ai_gepa/cli/run.py
@@ -29,6 +29,7 @@ from .layout import (
     config_path,
     final_report_path,
     insert_repo_root_on_path,
+    journal_path,
     new_run_id,
     repo_root,
     resolve_agent,
@@ -99,6 +100,9 @@ class RunState:
     eval_stall_timeout_secs: float = 600.0
     straggler_timeout_secs: float = 900.0
     journal_tail_lines: int = 20
+    # Set at fan-out/re-fan: the straggler-timeout clock starts here, immune
+    # to unrelated run-state saves refreshing updated_at (spec-er3).
+    iteration_started_at: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -147,6 +151,7 @@ class RunState:
             "eval_stall_timeout_secs": self.eval_stall_timeout_secs,
             "straggler_timeout_secs": self.straggler_timeout_secs,
             "journal_tail_lines": self.journal_tail_lines,
+            "iteration_started_at": self.iteration_started_at,
         }
 
     @staticmethod
@@ -252,6 +257,7 @@ class RunState:
             eval_stall_timeout_secs=float(data.get("eval_stall_timeout_secs", 600.0)),
             straggler_timeout_secs=float(data.get("straggler_timeout_secs", 900.0)),
             journal_tail_lines=int(data.get("journal_tail_lines", 20)),
+            iteration_started_at=data.get("iteration_started_at"),
         )
 
     def save(self) -> Path:
@@ -937,7 +943,9 @@ def start(
             )
             raise typer.Exit(code=2)
         # Lane branches are always cut from a clean commit; a dirty primary
-        # tree is rejected (spec-1do constraint).
+        # tree is rejected (spec-1do constraint). The journal is tracked
+        # bookkeeping the CLI itself appends to — exclude it like select does
+        # (one dirtiness definition across verbs).
         from .lanes import ensure_worktrees_ignored, worktrees_root
 
         workspace_root = repo_root()
@@ -948,6 +956,7 @@ def start(
                 exclude_paths=[
                     runs_dir(workspace_root),
                     worktrees_root(workspace_root),
+                    journal_path(workspace_root),
                 ],
             )
         except GitCandidateError as exc:
@@ -961,6 +970,30 @@ def start(
                 err=True,
             )
             raise typer.Exit(code=1)
+        # One active lane run per workspace (dec-jh6): an existing lane run
+        # that never reached `done` still owns its lane refs and events.
+        from .layout import is_run_id
+
+        for entry in sorted(runs_dir(workspace_root).iterdir()):
+            if not (entry.is_dir() and is_run_id(entry.name)):
+                continue
+            prior_state_path = entry / "state.json"
+            if not prior_state_path.exists():
+                continue
+            try:
+                prior = RunState.from_dict(
+                    json.loads(prior_state_path.read_text(encoding="utf-8"))
+                )
+            except (json.JSONDecodeError, KeyError, ValueError):
+                continue
+            if prior.lanes > 0 and prior.status != "done":
+                typer.echo(
+                    f"Lane run {prior.run_id} is still active "
+                    f"(status {prior.status}); finish it (`gepa run select`) "
+                    "or abandon it before starting another lane run.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
     run_id = new_run_id()
     run_dir(run_id).mkdir(parents=True, exist_ok=True)
     now = utc_now_iso()
@@ -992,18 +1025,56 @@ def start(
     state, outcomes = _advance_to_reflection_or_done(state)
     state.save()
     if lanes > 0 and state.status == "paused_for_reflection":
+        # Lane branches are cut from the CURRENT best commit — re-check the
+        # primary hasn't moved since the (possibly minutes-old) clean check.
+        fresh_state = git_candidate_state(
+            workspace_root,
+            exclude_paths=[
+                runs_dir(workspace_root),
+                worktrees_root(workspace_root),
+                journal_path(workspace_root),
+            ],
+        )
+        if (
+            fresh_state.commit_sha != state.reflection_baseline_commit_sha
+            or fresh_state.dirty
+        ):
+            # The baseline was measured against a HEAD that has since moved;
+            # advance again so lanes branch off the code actually scored.
+            state = _with_timestamp(state, status="running")
+            state.save()
+            state, extra_outcomes = _advance_to_reflection_or_done(state)
+            outcomes.extend(extra_outcomes)
+            state.save()
+    if lanes > 0 and state.status == "paused_for_reflection":
         # Fan out: worktrees + packets + lane_ready events. The run-level
         # status returns to "running" — lanes carry the reflection pause.
         from .lanes import fan_out_lanes
 
         fan_out_lanes(state, repo_root())
         state = _with_timestamp(state, status="running")
+        state = replace(state, iteration_started_at=state.updated_at)
         state.save()
 
     final_path: Path | None = None
     final_text: str | None = None
     if state.status == "done":
         final_path, final_text = _write_final_report(state)
+        if lanes > 0:
+            # A lane run can finish during the baseline advance; the
+            # orchestrator loop terminates on run_done, so emit it here too.
+            from .events import EventDraft, emit
+
+            emit(
+                state.run_id,
+                "run",
+                EventDraft(
+                    type="run_done",
+                    lane=None,
+                    payload={"final_report_path": str(final_path)},
+                ),
+                root=workspace_root,
+            )
     _emit_status(
         state, outcomes=outcomes, final_report=final_path, final_report_text=final_text
     )

--- a/tests/cli/test_eval_cli.py
+++ b/tests/cli/test_eval_cli.py
@@ -393,7 +393,9 @@ def test_eval_artifact_names_are_collision_free(
 
     # Force both evals to observe the same iteration ordinal, simulating the
     # check-then-append race between concurrent lane evals.
-    monkeypatch.setattr(eval_module, "_count_evals_in_run", lambda _run_id: 0)
+    monkeypatch.setattr(
+        eval_module, "_count_evals_in_run", lambda _run_id, root=None: 0
+    )
 
     second = _run(
         "eval",

--- a/tests/cli/test_lanes_cli.py
+++ b/tests/cli/test_lanes_cli.py
@@ -1,0 +1,501 @@
+"""End-to-end coverage for reflection lanes (spec-1do, task-xcb)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import Result
+from typer.testing import CliRunner
+
+from pydantic_ai_gepa.cli import app as gepa_app
+from pydantic_ai_gepa.cli.lanes import (
+    LaneState,
+    load_lane_state,
+)
+from pydantic_ai_gepa.cli.run import RunState
+
+EVALUATE_MODULE_SOURCE = textwrap.dedent("""
+    async def evaluate(case):
+        from pathlib import Path
+
+        return Path("score.txt").read_text(encoding="utf-8").strip()
+""").lstrip()
+
+
+def _run(*argv: str) -> Result:
+    return CliRunner().invoke(gepa_app, list(argv))
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_payload(output: str) -> dict[str, object]:
+    line = next(
+        line
+        for line in reversed(output.splitlines())
+        if line.startswith("{") and '"run"' in line
+    )
+    return json.loads(line)["run"]
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    # Lane verbs set layout globals via --gepa-dir; save/restore them so the
+    # override cannot leak into the next test's init.
+    from pydantic_ai_gepa.cli import layout
+
+    saved_dirname = layout._explicit_gepa_dirname
+    saved_env = os.environ.get("GEPA_DIR")
+    monkeypatch.delenv("GEPA_DIR", raising=False)
+
+    module_dir = tmp_path / "task_pkg"
+    module_dir.mkdir()
+    (module_dir / "__init__.py").touch()
+    (module_dir / "evaluation.py").write_text(EVALUATE_MODULE_SOURCE, encoding="utf-8")
+    (tmp_path / "score.txt").write_text("bad\n", encoding="utf-8")
+    (tmp_path / ".gitignore").write_text(
+        "__pycache__/\n.gepa/runs/\n", encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    init_result = _run(
+        "init",
+        "--candidate-source",
+        "git",
+        "--evaluate",
+        "task_pkg.evaluation:evaluate",
+    )
+    assert init_result.exit_code == 0, init_result.output
+    (tmp_path / ".gepa" / "dataset.jsonl").write_text(
+        json.dumps({"name": "case-1", "inputs": "x", "expected_output": "good"}) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".gepa" / "journal.jsonl").write_text(
+        json.dumps({"timestamp": "t0", "content": "seed entry", "strategy": "seed"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "tests@example.com")
+    _git(tmp_path, "config", "user.name", "GEPA Tests")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "Seed git candidate")
+
+    yield tmp_path
+
+    layout._explicit_gepa_dirname = saved_dirname
+    if saved_env is None:
+        os.environ.pop("GEPA_DIR", None)
+    else:
+        os.environ["GEPA_DIR"] = saved_env
+
+    for name in list(sys.modules):
+        if name.startswith("task_pkg"):
+            sys.modules.pop(name, None)
+
+
+def _start_lane_run(repo: Path, lanes: int = 2) -> dict[str, object]:
+    result = _run(
+        "run",
+        "start",
+        "--lanes",
+        str(lanes),
+        "--size",
+        "1",
+        "--acceptance-repetitions",
+        "1",
+    )
+    assert result.exit_code == 0, result.output
+    return _run_payload(result.output)
+
+
+def _lane_state(repo: Path, run_id: str, lane: str) -> LaneState:
+    return load_lane_state(repo, run_id, lane)
+
+
+def test_run_start_lanes_fans_out(git_repo: Path) -> None:
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = str(run["run_id"])
+    assert run["lanes"] == 2
+    assert run["status"] == "running"
+    assert run["next_command"] == f"gepa next --wait --run-id {run_id}"
+
+    # Worktrees + branches cut from the frozen baseline commit.
+    base_sha = _git(git_repo, "rev-parse", "HEAD")
+    for lane in ("lane-1", "lane-2"):
+        worktree = git_repo / "worktrees" / lane
+        assert worktree.is_dir()
+        assert _git(worktree, "rev-parse", "HEAD") == base_sha
+        state = _lane_state(git_repo, run_id, lane)
+        assert state.status == "paused_for_reflection"
+        assert state.branch == f"gepa/lane/{lane}/{state.iteration}"
+        assert Path(str(state.packet_path)).exists()
+
+    # lane_ready events emitted with packet + worktree paths.
+    events_dir = git_repo / ".gepa" / "runs" / run_id / "events"
+    ids = sorted(p.name for p in events_dir.iterdir())
+    assert len(ids) == 2
+    events = [json.loads((events_dir / eid).read_text()) for eid in ids]
+    assert {event["type"] for event in events} == {"lane_ready"}
+    for event in events:
+        assert Path(event["payload"]["packet_path"]).exists()
+        assert Path(event["payload"]["worktree_path"]).is_dir()
+
+
+def test_run_start_lanes_rejects_dirty_primary(git_repo: Path) -> None:
+    (git_repo / "score.txt").write_text("worse\n", encoding="utf-8")
+    result = _run("run", "start", "--lanes", "2", "--size", "1")
+    assert result.exit_code == 1
+    assert "clean primary tree" in result.output
+
+
+def test_run_start_lanes_rejects_component_mode(git_repo: Path) -> None:
+    result = _run(
+        "run",
+        "start",
+        "--lanes",
+        "2",
+        "--size",
+        "1",
+        "--candidate-source",
+        "components",
+    )
+    assert result.exit_code == 2
+    assert "git candidate mode" in result.output
+
+
+def test_run_continue_errors_in_lane_run(git_repo: Path) -> None:
+    run = _start_lane_run(git_repo)
+    result = _run("run", "continue", "--run-id", str(run["run_id"]))
+    assert result.exit_code == 1
+    assert "gepa lane continue" in result.output
+    assert "gepa run select" in result.output
+
+
+def test_single_path_run_untouched(git_repo: Path) -> None:
+    """--lanes absent -> existing synchronous path: no worktrees, no events."""
+    result = _run("run", "start", "--size", "1", "--acceptance-repetitions", "1")
+    assert result.exit_code == 0, result.output
+    run = _run_payload(result.output)
+    assert run["lanes"] == 0
+    assert run["status"] == "paused_for_reflection"
+    run_id = str(run["run_id"])
+    assert not (git_repo / "worktrees").exists()
+    assert not (git_repo / ".gepa" / "runs" / run_id / "events").exists()
+    assert run["next_command"] == f"gepa run continue --run-id {run_id}"
+
+
+def test_pre_lane_state_loads_with_lane_defaults(git_repo: Path) -> None:
+    result = _run("run", "start", "--size", "1", "--acceptance-repetitions", "1")
+    assert result.exit_code == 0, result.output
+    run = _run_payload(result.output)
+    state_path = Path(str(run["state_path"]))
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    for key in (
+        "lanes",
+        "heartbeat_interval_secs",
+        "reflection_lease_secs",
+        "eval_stall_timeout_secs",
+        "straggler_timeout_secs",
+        "journal_tail_lines",
+    ):
+        raw.pop(key, None)
+    state = RunState.from_dict(raw)
+    assert state.lanes == 0
+    assert state.heartbeat_interval_secs == 10.0
+    assert state.reflection_lease_secs == 1800.0
+    assert state.eval_stall_timeout_secs == 600.0
+    assert state.straggler_timeout_secs == 900.0
+    assert state.journal_tail_lines == 20
+
+
+def test_packet_is_self_contained(git_repo: Path) -> None:
+    run = _start_lane_run(git_repo, lanes=1)
+    state = _lane_state(git_repo, str(run["run_id"]), "lane-1")
+    packet = json.loads(Path(str(state.packet_path)).read_text(encoding="utf-8"))
+
+    assert packet["packet_version"] == 1
+    assert packet["lane"] == "lane-1"
+    assert Path(packet["worktree_path"]).is_dir()
+    baseline = packet["baseline"]
+    assert baseline["samples"] == [0.0]
+    assert baseline["minibatch_id"]
+    assert all(Path(p).exists() for p in baseline["report_paths"])
+    assert packet["journal_tail"][0]["content"] == "seed entry"
+    invocation = packet["continue_invocation"]
+    assert "lane continue lane-1" in invocation
+    assert f"--run-id {run['run_id']}" in invocation
+    # The invocation carries the absolute workspace explicitly (dec-780).
+    assert f"--gepa-dir {git_repo}/.gepa" in invocation
+
+
+def test_lane_lease_and_double_lease_rejected(git_repo: Path) -> None:
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+
+    leased = _run("--gepa-dir", gepa_dir, "lane", "lease", "lane-1", "--run-id", run_id)
+    assert leased.exit_code == 0, leased.output
+    state = _lane_state(git_repo, run_id, "lane-1")
+    assert state.status == "leased"
+    assert state.lease_epoch == 1
+    assert state.lease_expires_at is not None
+
+    again = _run("--gepa-dir", gepa_dir, "lane", "lease", "lane-1", "--run-id", run_id)
+    assert again.exit_code == 1
+    assert "already leased" in again.output
+
+
+def test_lane_continue_evaluates_and_emits_verdict(git_repo: Path) -> None:
+    """Reflector flow end-to-end: edit worktree, continue, verdict lands."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+    primary_head = _git(git_repo, "rev-parse", "HEAD")
+
+    # The reflector improves the candidate inside the lane worktree only.
+    worktree = git_repo / "worktrees" / "lane-1"
+    (worktree / "score.txt").write_text("good\n", encoding="utf-8")
+
+    # Invoke from inside the worktree using only the packet's invocation
+    # fields (explicit absolute gepa-dir + run id + lane id).
+    import os
+
+    old_cwd = Path.cwd()
+    os.chdir(worktree)
+    try:
+        result = _run(
+            "--gepa-dir",
+            gepa_dir,
+            "lane",
+            "continue",
+            "lane-1",
+            "--run-id",
+            run_id,
+            "--foreground",
+        )
+    finally:
+        os.chdir(old_cwd)
+    assert result.exit_code == 0, result.output
+    assert "accepted" in result.output
+
+    # Auto-commit landed on the lane branch; candidate is a clean commit.
+    lane_head = _git(worktree, "rev-parse", "HEAD")
+    assert lane_head != primary_head
+    assert _git(worktree, "status", "--porcelain") == ""
+    assert _git(git_repo, "rev-parse", "HEAD") == primary_head  # primary untouched
+
+    state = _lane_state(git_repo, run_id, "lane-1")
+    assert state.status == "awaiting_selection"
+    assert state.verdict == "accepted"
+    assert state.verdict_delta == pytest.approx(1.0)
+    assert state.candidate_sha == lane_head
+    assert state.eval_samples == (1.0,)
+    assert state.eval_pid is None
+    assert Path(str(state.comparison_path)).exists()
+
+    # Verdict event + lane-scoped ledger row with collision-free artifacts.
+    events_dir = git_repo / ".gepa" / "runs" / run_id / "events"
+    verdict_events = [
+        json.loads(p.read_text())
+        for p in events_dir.iterdir()
+        if json.loads(p.read_text())["type"] == "verdict"
+    ]
+    assert len(verdict_events) == 1
+    assert verdict_events[0]["lane"] == "lane-1"
+    assert verdict_events[0]["payload"]["verdict"] == "accepted"
+
+    from pydantic_ai_gepa.cli.runs import ParetoLog
+
+    rows = ParetoLog(run_id, git_repo).iter_rows()
+    lane_rows = [row for row in rows if row.lane == "lane-1"]
+    assert len(lane_rows) == 1
+    assert lane_rows[0].mean_score == pytest.approx(1.0)
+
+
+def test_two_lanes_evaluate_in_distinct_worktrees(git_repo: Path) -> None:
+    """Two lanes -> distinct clean-commit candidate ids; primary untouched."""
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+    primary_head = _git(git_repo, "rev-parse", "HEAD")
+
+    edits = {"lane-1": "good\n", "lane-2": "good\n\n"}
+    import os
+
+    old_cwd = Path.cwd()
+    try:
+        for lane, content in edits.items():
+            worktree = git_repo / "worktrees" / lane
+            (worktree / "score.txt").write_text(content, encoding="utf-8")
+            os.chdir(worktree)
+            result = _run(
+                "--gepa-dir",
+                gepa_dir,
+                "lane",
+                "continue",
+                lane,
+                "--run-id",
+                run_id,
+                "--foreground",
+            )
+            assert result.exit_code == 0, result.output
+    finally:
+        os.chdir(old_cwd)
+
+    state_1 = _lane_state(git_repo, run_id, "lane-1")
+    state_2 = _lane_state(git_repo, run_id, "lane-2")
+    assert state_1.candidate_sha != state_2.candidate_sha
+    assert state_1.verdict == state_2.verdict == "accepted"
+    assert _git(git_repo, "rev-parse", "HEAD") == primary_head
+    assert _git(git_repo, "status", "--porcelain") == ""
+
+
+def test_second_continue_on_evaluating_lane_rejected(git_repo: Path) -> None:
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+
+    # Simulate an in-flight eval: status evaluating with a live pid.
+    sleeper = subprocess.Popen(["sleep", "30"])
+    try:
+        state = _lane_state(git_repo, run_id, "lane-1")
+        state = LaneState(
+            **{
+                **state.to_dict(),
+                "status": "evaluating",
+                "eval_pid": sleeper.pid,
+                "heartbeat_at": state.updated_at,
+            }
+        )
+        state.save(git_repo, run_id)
+
+        result = _run(
+            "--gepa-dir",
+            gepa_dir,
+            "lane",
+            "continue",
+            "lane-1",
+            "--run-id",
+            run_id,
+            "--foreground",
+        )
+        assert result.exit_code == 1
+        assert "already evaluating" in result.output
+        after = _lane_state(git_repo, run_id, "lane-1")
+        assert after.status == "evaluating"
+        assert after.eval_pid == sleeper.pid
+    finally:
+        sleeper.terminate()
+        sleeper.wait()
+
+
+def test_lane_reset_terminates_live_eval_and_preserves_worktree(
+    git_repo: Path,
+) -> None:
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+
+    worktree = git_repo / "worktrees" / "lane-1"
+    (worktree / "notes.txt").write_text("uncommitted work\n", encoding="utf-8")
+
+    sleeper = subprocess.Popen(["sleep", "30"])
+    try:
+        state = _lane_state(git_repo, run_id, "lane-1")
+        LaneState(
+            **{
+                **state.to_dict(),
+                "status": "evaluating",
+                "eval_pid": sleeper.pid,
+                "heartbeat_at": state.updated_at,
+            }
+        ).save(git_repo, run_id)
+
+        result = _run(
+            "--gepa-dir", gepa_dir, "lane", "reset", "lane-1", "--run-id", run_id
+        )
+        assert result.exit_code == 0, result.output
+        deadline = time.monotonic() + 5.0
+        while sleeper.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert sleeper.poll() is not None  # terminated by reset
+    finally:
+        if sleeper.poll() is None:
+            sleeper.kill()
+            sleeper.wait()
+
+    state = _lane_state(git_repo, run_id, "lane-1")
+    assert state.status == "paused_for_reflection"
+    assert state.eval_pid is None
+    assert state.lease_epoch == 1
+    # Uncommitted worktree content is never auto-deleted.
+    assert (worktree / "notes.txt").read_text(encoding="utf-8") == "uncommitted work\n"
+
+
+def test_run_status_renders_lane_board_and_reaps(git_repo: Path) -> None:
+    """run status renders every lane and synthesizes lane_stalled exactly once."""
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = str(run["run_id"])
+
+    # Fake a dead eval on lane-1: recorded pid that no longer exists.
+    state = _lane_state(git_repo, run_id, "lane-1")
+    LaneState(
+        **{
+            **state.to_dict(),
+            "status": "evaluating",
+            "eval_pid": 999_999_999,
+            "heartbeat_at": state.updated_at,
+        }
+    ).save(git_repo, run_id)
+
+    first = _run("run", "status", "--run-id", run_id)
+    assert first.exit_code == 0, first.output
+    payload = json.loads(first.output)
+    lanes = {lane["lane"]: lane for lane in payload["lanes"]}
+    assert set(lanes) == {"lane-1", "lane-2"}
+    assert lanes["lane-1"]["status"] == "evaluating"
+    assert lanes["lane-2"]["status"] == "paused_for_reflection"
+
+    events_dir = git_repo / ".gepa" / "runs" / run_id / "events"
+    stalled = [
+        json.loads(p.read_text())
+        for p in events_dir.iterdir()
+        if json.loads(p.read_text())["type"] == "lane_stalled"
+    ]
+    assert len(stalled) == 1
+    assert stalled[0]["lane"] == "lane-1"
+    assert "dead" in stalled[0]["payload"]["reason"]
+
+    # A second status pass re-synthesizes nothing for the same lease epoch.
+    second = _run("run", "status", "--run-id", run_id)
+    assert second.exit_code == 0, second.output
+    stalled = [
+        json.loads(p.read_text())
+        for p in events_dir.iterdir()
+        if json.loads(p.read_text())["type"] == "lane_stalled"
+    ]
+    assert len(stalled) == 1
+
+
+def test_lane_verb_requires_explicit_absolute_workspace(git_repo: Path) -> None:
+    run = _start_lane_run(git_repo, lanes=1)
+    result = _run("lane", "reset", "lane-1", "--run-id", str(run["run_id"]))
+    assert result.exit_code != 0
+    assert "absolute workspace" in result.output or "GEPA_DIR" in result.output

--- a/tests/cli/test_lanes_cli.py
+++ b/tests/cli/test_lanes_cli.py
@@ -149,7 +149,7 @@ def test_run_start_lanes_fans_out(git_repo: Path) -> None:
 
     # lane_ready events emitted with packet + worktree paths.
     events_dir = git_repo / ".gepa" / "runs" / run_id / "events"
-    ids = sorted(p.name for p in events_dir.iterdir())
+    ids = sorted(p.name for p in events_dir.iterdir() if p.is_file())
     assert len(ids) == 2
     events = [json.loads((events_dir / eid).read_text()) for eid in ids]
     assert {event["type"] for event in events} == {"lane_ready"}
@@ -311,11 +311,12 @@ def test_lane_continue_evaluates_and_emits_verdict(git_repo: Path) -> None:
     assert Path(str(state.comparison_path)).exists()
 
     # Verdict event + lane-scoped ledger row with collision-free artifacts.
-    events_dir = git_repo / ".gepa" / "runs" / run_id / "events"
+    from pydantic_ai_gepa.cli.events import list_events
+
     verdict_events = [
-        json.loads(p.read_text())
-        for p in events_dir.iterdir()
-        if json.loads(p.read_text())["type"] == "verdict"
+        event.to_dict()
+        for event in list_events(run_id, git_repo)
+        if event.type == "verdict"
     ]
     assert len(verdict_events) == 1
     assert verdict_events[0]["lane"] == "lane-1"
@@ -473,23 +474,20 @@ def test_run_status_renders_lane_board_and_reaps(git_repo: Path) -> None:
     assert lanes["lane-1"]["status"] == "evaluating"
     assert lanes["lane-2"]["status"] == "paused_for_reflection"
 
-    events_dir = git_repo / ".gepa" / "runs" / run_id / "events"
+    from pydantic_ai_gepa.cli.events import list_events
+
     stalled = [
-        json.loads(p.read_text())
-        for p in events_dir.iterdir()
-        if json.loads(p.read_text())["type"] == "lane_stalled"
+        event for event in list_events(run_id, git_repo) if event.type == "lane_stalled"
     ]
     assert len(stalled) == 1
-    assert stalled[0]["lane"] == "lane-1"
-    assert "dead" in stalled[0]["payload"]["reason"]
+    assert stalled[0].lane == "lane-1"
+    assert "dead" in stalled[0].payload["reason"]
 
     # A second status pass re-synthesizes nothing for the same lease epoch.
     second = _run("run", "status", "--run-id", run_id)
     assert second.exit_code == 0, second.output
     stalled = [
-        json.loads(p.read_text())
-        for p in events_dir.iterdir()
-        if json.loads(p.read_text())["type"] == "lane_stalled"
+        event for event in list_events(run_id, git_repo) if event.type == "lane_stalled"
     ]
     assert len(stalled) == 1
 

--- a/tests/cli/test_lanes_cli.py
+++ b/tests/cli/test_lanes_cli.py
@@ -18,6 +18,7 @@ from typer.testing import CliRunner
 from pydantic_ai_gepa.cli import app as gepa_app
 from pydantic_ai_gepa.cli.lanes import (
     LaneState,
+    lane_state_path,
     load_lane_state,
 )
 from pydantic_ai_gepa.cli.run import RunState
@@ -139,12 +140,12 @@ def test_run_start_lanes_fans_out(git_repo: Path) -> None:
     # Worktrees + branches cut from the frozen baseline commit.
     base_sha = _git(git_repo, "rev-parse", "HEAD")
     for lane in ("lane-1", "lane-2"):
-        worktree = git_repo / "worktrees" / lane
+        worktree = git_repo / "worktrees" / run_id / lane
         assert worktree.is_dir()
         assert _git(worktree, "rev-parse", "HEAD") == base_sha
         state = _lane_state(git_repo, run_id, lane)
         assert state.status == "paused_for_reflection"
-        assert state.branch == f"gepa/lane/{lane}/{state.iteration}"
+        assert state.branch == f"gepa/lane/{run_id}/{lane}/{state.iteration}"
         assert Path(str(state.packet_path)).exists()
 
     # lane_ready events emitted with packet + worktree paths.
@@ -270,7 +271,7 @@ def test_lane_continue_evaluates_and_emits_verdict(git_repo: Path) -> None:
     primary_head = _git(git_repo, "rev-parse", "HEAD")
 
     # The reflector improves the candidate inside the lane worktree only.
-    worktree = git_repo / "worktrees" / "lane-1"
+    worktree = git_repo / "worktrees" / run_id / "lane-1"
     (worktree / "score.txt").write_text("good\n", encoding="utf-8")
 
     # Invoke from inside the worktree using only the packet's invocation
@@ -343,7 +344,7 @@ def test_two_lanes_evaluate_in_distinct_worktrees(git_repo: Path) -> None:
     old_cwd = Path.cwd()
     try:
         for lane, content in edits.items():
-            worktree = git_repo / "worktrees" / lane
+            worktree = git_repo / "worktrees" / run_id / lane
             (worktree / "score.txt").write_text(content, encoding="utf-8")
             os.chdir(worktree)
             result = _run(
@@ -414,7 +415,7 @@ def test_lane_reset_terminates_live_eval_and_preserves_worktree(
     run_id = str(run["run_id"])
     gepa_dir = str(git_repo / ".gepa")
 
-    worktree = git_repo / "worktrees" / "lane-1"
+    worktree = git_repo / "worktrees" / run_id / "lane-1"
     (worktree / "notes.txt").write_text("uncommitted work\n", encoding="utf-8")
 
     sleeper = subprocess.Popen(["sleep", "30"])
@@ -471,7 +472,10 @@ def test_run_status_renders_lane_board_and_reaps(git_repo: Path) -> None:
     payload = json.loads(first.output)
     lanes = {lane["lane"]: lane for lane in payload["lanes"]}
     assert set(lanes) == {"lane-1", "lane-2"}
-    assert lanes["lane-1"]["status"] == "evaluating"
+    # The reaper transitions the dead-pid lane's STATE to stalled (dec-l95),
+    # not just an event on the bus.
+    assert lanes["lane-1"]["status"] == "stalled"
+    assert lanes["lane-1"]["eval_pid"] is None
     assert lanes["lane-2"]["status"] == "paused_for_reflection"
 
     from pydantic_ai_gepa.cli.events import list_events
@@ -497,3 +501,177 @@ def test_lane_verb_requires_explicit_absolute_workspace(git_repo: Path) -> None:
     result = _run("lane", "reset", "lane-1", "--run-id", str(run["run_id"]))
     assert result.exit_code != 0
     assert "absolute workspace" in result.output or "GEPA_DIR" in result.output
+
+
+# ---------- adversarial-review hardening (PR #29 review) ----------
+
+
+def test_second_lane_run_rejected(git_repo: Path) -> None:
+    """One active lane run per workspace (dec-jh6): a second `run start
+    --lanes` while the first is active is refused before any fan-out."""
+    _start_lane_run(git_repo, lanes=1)
+    result = _run("run", "start", "--lanes", "1", "--size", "1")
+    assert result.exit_code == 1
+    assert "still active" in result.output
+    # No second run dir was created with lanes.
+    runs = [p for p in (git_repo / ".gepa" / "runs").iterdir() if p.is_dir()]
+    assert len(runs) == 1
+
+
+def test_lane_verbs_reject_done_runs(git_repo: Path) -> None:
+    """Lane verbs refuse to run on completed runs (spec-1do: lanes are
+    re-fanned at select or removed when the run completes)."""
+    result = _run(
+        "run",
+        "start",
+        "--lanes",
+        "1",
+        "--size",
+        "1",
+        "--acceptance-repetitions",
+        "1",
+        "--max-iterations",
+        "1",
+    )
+    assert result.exit_code == 0, result.output
+    run = _run_payload(result.output)
+    assert run["status"] == "done"  # budget exhausted by the baseline eval
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+
+    # run_done is emitted even though no select ever ran.
+    from pydantic_ai_gepa.cli.events import list_events
+
+    done_events = [e for e in list_events(run_id, git_repo) if e.type == "run_done"]
+    assert len(done_events) == 1
+
+    lease = _run("--gepa-dir", gepa_dir, "lane", "lease", "lane-1", "--run-id", run_id)
+    assert lease.exit_code == 1
+    assert "done" in lease.output
+
+
+def test_second_continue_on_leased_lane_rejected(git_repo: Path) -> None:
+    """A leased lane rejects a concurrent `lane continue` until the lease is
+    consumed, reset, or expires (spec-1do mutual exclusion)."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+
+    leased = _run("--gepa-dir", gepa_dir, "lane", "lease", "lane-1", "--run-id", run_id)
+    assert leased.exit_code == 0, leased.output
+
+    # A parent-mode continue (spawn path) is rejected while leased.
+    result = _run(
+        "--gepa-dir", gepa_dir, "lane", "continue", "lane-1", "--run-id", run_id
+    )
+    assert result.exit_code == 1
+    assert "leased" in result.output
+    state = _lane_state(git_repo, run_id, "lane-1")
+    assert state.status == "leased"
+    assert state.lease_epoch == 1
+
+
+def test_lane_reset_refuses_awaiting_selection(git_repo: Path) -> None:
+    """A resolved lane's verdict is never destroyed unrecorded."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+    worktree = git_repo / "worktrees" / run_id / "lane-1"
+    (worktree / "score.txt").write_text("good\n", encoding="utf-8")
+
+    import os
+
+    old_cwd = Path.cwd()
+    os.chdir(worktree)
+    try:
+        result = _run(
+            "--gepa-dir",
+            gepa_dir,
+            "lane",
+            "continue",
+            "lane-1",
+            "--run-id",
+            run_id,
+            "--foreground",
+        )
+    finally:
+        os.chdir(old_cwd)
+    assert result.exit_code == 0, result.output
+    assert _lane_state(git_repo, run_id, "lane-1").status == "awaiting_selection"
+
+    reset = _run("--gepa-dir", gepa_dir, "lane", "reset", "lane-1", "--run-id", run_id)
+    assert reset.exit_code == 1
+    assert "awaiting_selection" in reset.output
+    # Verdict intact.
+    state = _lane_state(git_repo, run_id, "lane-1")
+    assert state.verdict == "accepted"
+    assert state.status == "awaiting_selection"
+
+
+def test_foreground_continue_evaluates_worktree_not_primary(git_repo: Path) -> None:
+    """Foreground continue invoked from the PRIMARY checkout still evaluates
+    the lane worktree's tree (the loop chdirs to the candidate root)."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+    gepa_dir = str(git_repo / ".gepa")
+    worktree = git_repo / "worktrees" / run_id / "lane-1"
+    (worktree / "score.txt").write_text("good\n", encoding="utf-8")
+    # Primary still scores "bad".
+    assert (git_repo / "score.txt").read_text(encoding="utf-8") == "bad\n"
+
+    result = _run(
+        "--gepa-dir",
+        gepa_dir,
+        "lane",
+        "continue",
+        "lane-1",
+        "--run-id",
+        run_id,
+        "--foreground",
+    )
+    assert result.exit_code == 0, result.output
+    assert "accepted" in result.output
+    state = _lane_state(git_repo, run_id, "lane-1")
+    assert state.verdict == "accepted"
+
+
+def test_stale_heartbeat_with_live_pid_is_not_stalled(git_repo: Path) -> None:
+    """spec-1do: eval death = stale heartbeat PLUS dead pid. A slow but alive
+    eval is never reaped (the documented response kills the pid)."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = str(run["run_id"])
+
+    sleeper = subprocess.Popen(["sleep", "30"])
+    try:
+        state = _lane_state(git_repo, run_id, "lane-1")
+        LaneState(
+            **{
+                **state.to_dict(),
+                "status": "evaluating",
+                "eval_pid": sleeper.pid,
+                "heartbeat_at": "2020-01-01T00:00:00+00:00",  # ancient
+            }
+        ).save(git_repo, run_id)
+
+        result = _run("run", "status", "--run-id", run_id)
+        assert result.exit_code == 0, result.output
+        from pydantic_ai_gepa.cli.events import list_events
+
+        stalled = [e for e in list_events(run_id, git_repo) if e.type == "lane_stalled"]
+        assert stalled == []
+        lanes = {lane["lane"]: lane for lane in json.loads(result.output)["lanes"]}
+        assert lanes["lane-1"]["status"] == "evaluating"
+    finally:
+        sleeper.terminate()
+        sleeper.wait()
+
+
+def test_corrupt_lane_state_gives_actionable_error(git_repo: Path) -> None:
+    started = _start_lane_run(git_repo, lanes=1)
+    run_id = str(started["run_id"])
+    path = lane_state_path(git_repo, run_id, "lane-1")
+    path.write_text("{torn", encoding="utf-8")
+    gepa_dir = str(git_repo / ".gepa")
+    result = _run("--gepa-dir", gepa_dir, "lane", "lease", "lane-1", "--run-id", run_id)
+    assert result.exit_code != 0
+    assert "corrupt" in result.output or "lane reset" in result.output


### PR DESCRIPTION
## Stack position: 3/5 — base: `lanes/2-event-bus` (#28, base chain: #27 → #28 → this)

Implements pydanticaigepa-task-xcb — the lane lifecycle slice of the reflection-lanes stack.

### Governing contracts (accepted on `main`)

- **spec-1do** — lane lifecycle: worktree layout, single-writer per-lane state, lease state machine, background acceptance eval, append-only ledger.
- **dec-780** — lane processes locate the workspace explicitly (absolute `--gepa-dir` / run id / lane id from packet or flags, `GEPA_DIR` fallback); no cwd walking.
- **dec-tlz** — `lane continue` auto-commits onto `gepa/lane/<lane>/<iteration>`; clean primary tree required at start; worktrees gitignored under `<workspace>/worktrees/` (via `.git/info/exclude` — never a tracked-file edit, so the primary stays clean).
- **dec-pm3** — the lazy reaper now has its real scanner: heartbeat staleness, pid liveness, lease expiry.
- **dec-msy** — lane evals append ledger rows with `lane=<lane>`; per-eval budget check advisory.

### What changes

- **New `cli/lanes.py`** (~700 lines):
  - `LaneState` persisted at `runs/<run_id>/lanes/<lane>/state.json` (status, lease epoch/expiry, candidate sha, eval samples, verdict, heartbeat, eval pid, packet path) implementing the spec-1do States table; written only by the lane's own eval process or lifecycle verbs.
  - `gepa run start --lanes N`: rejects dirty primary trees and component mode; creates N worktrees under `<workspace>/worktrees/<lane>/` on branches `gepa/lane/<lane>/<iteration>` cut from the frozen baseline commit; runs the shared baseline once; writes versioned `packet.json` (baseline samples + report/trace paths, metric side info, bounded journal tail, worktree path, exact continue invocation); emits `lane_ready` per lane.
  - `gepa lane lease <lane>`: dispatch lease with epoch + expiry; double-dispatch rejected.
  - `gepa lane continue <lane>`: resolves workspace explicitly; rejects a second concurrent continue at every point of the handoff (parent leases before spawning, child performs the `leased → evaluating` transition recording its own pid); auto-commits the worktree; runs the repeated-evaluation acceptance policy (`compare_candidate_samples` against the frozen baseline) **detached**, streaming progress + heartbeat into lane state and emitting `verdict` on resolution. `--foreground` runs in-process (used by the detached child and tests).
  - `gepa lane reset <lane>`: terminates a live recorded eval pid (SIGTERM, zombie-safe liveness check) before resetting; uncommitted worktree content preserved.
  - Real lane scanner for the reaper: `scan_lane_states` (dead pid / stale heartbeat / expired lease → `lane_stalled`; all-resolved or straggler timeout → `selection_due`); `events.scan_lanes` now delegates to it, keeping the slice-2 result-object interface.
- **`cli/run.py`**: `RunState` gains lane fields (all defaulted — pre-lane `state.json` files load unchanged); `run start` gains `--lanes` + per-spec timeout flags (no hardcoded timeouts); `run continue` in a lane run exits naming `gepa lane continue` / `gepa run select`; `run status` renders the lane board (`lanes` key) after a reaper pass; `next_command` for lane runs points at `gepa next --wait`.
- **`cli/eval.py`**: `run_eval_once` gains `candidate_root` / `workspace_root` so lane evals resolve candidate identity and imports from the worktree while config/dataset/ledger/artifacts resolve from the primary workspace.

`--lanes` absent → the synchronous single-path path is untouched (no worktrees, no events) — test `test_single_path_run_untouched`.

### Validation

- 14 new tests in `tests/cli/test_lanes_cli.py` covering the spec-1do Verifications: fan-out, dirty-primary rejection, component-mode rejection, `run continue` error, single-path untouched, pre-lane state defaults, self-contained packet, lease + double-lease rejection, foreground continue → verdict event + ledger row + clean auto-commit, two lanes in distinct worktrees with distinct candidate ids (primary untouched), second-continue rejection while evaluating, reset terminating a live pid while preserving uncommitted work, status board + reaper idempotency, explicit-workspace requirement.
- Real detached-mode smoke test (out-of-process `gepa` binary): lane continue spawned a background eval that auto-committed to the lane branch, refreshed heartbeat/pid, emitted `verdict accepted (delta +1.0)`, and `gepa next` delivered lane_ready → (ack) → verdict, with the reaper synthesizing `selection_due` once the lane resolved.
- `uv run pytest tests/cli` → 190 passed; `ruff check` + `ruff format --check` clean; `pyright` clean on lanes.py.

### Out of scope (slice 4, task-vso)

Selection/promotion, straggler invalidation, journal write-back of losers, merge_opportunity, re-fan/re-baseline, budget stop at select.