### PR TITLE
gepa run select: lockstep multi-way selection and re-fan (stack 4/5)

### DIFF
--- a/src/pydantic_ai_gepa/cli/run.py
+++ b/src/pydantic_ai_gepa/cli/run.py
@@ -103,6 +103,12 @@ class RunState:
     # Set at fan-out/re-fan: the straggler-timeout clock starts here, immune
     # to unrelated run-state saves refreshing updated_at (spec-er3).
     iteration_started_at: str | None = None
+    # Select-phase resumption markers (spec-er3). ``select_phase`` is the
+    # in-flight marker: non-None while a `gepa run select` is between phase
+    # checkpoints; ``select_context`` carries the resumption record (pid,
+    # winner, per-lane progress) so an interrupted select resumes idempotently.
+    select_phase: str | None = None
+    select_context: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -152,6 +158,8 @@ class RunState:
             "straggler_timeout_secs": self.straggler_timeout_secs,
             "journal_tail_lines": self.journal_tail_lines,
             "iteration_started_at": self.iteration_started_at,
+            "select_phase": self.select_phase,
+            "select_context": self.select_context,
         }
 
     @staticmethod
@@ -258,6 +266,16 @@ class RunState:
             straggler_timeout_secs=float(data.get("straggler_timeout_secs", 900.0)),
             journal_tail_lines=int(data.get("journal_tail_lines", 20)),
             iteration_started_at=data.get("iteration_started_at"),
+            select_phase=(
+                str(data["select_phase"])
+                if data.get("select_phase") is not None
+                else None
+            ),
+            select_context=(
+                dict(data["select_context"])
+                if isinstance(data.get("select_context"), dict)
+                else None
+            ),
         )
 
     def save(self) -> Path:
@@ -636,9 +654,11 @@ def _current_baseline_candidate_id(
     return candidate_id_from_components(components)
 
 
-def _write_final_report(state: RunState) -> tuple[Path, str]:
-    rows = ParetoLog(state.run_id).iter_rows()
-    path = final_report_path(state.run_id)
+def _write_final_report(
+    state: RunState, *, overshoot: int | None = None, root: Path | None = None
+) -> tuple[Path, str]:
+    rows = ParetoLog(state.run_id, root).iter_rows()
+    path = final_report_path(state.run_id, root)
     path.parent.mkdir(parents=True, exist_ok=True)
 
     lines = [
@@ -647,8 +667,14 @@ def _write_final_report(state: RunState) -> tuple[Path, str]:
         f"- run_id: {state.run_id}",
         f"- status: {state.status}",
         f"- iterations: {state.iterations}/{state.max_iterations}",
-        f"- pareto_log: {ParetoLog(state.run_id).path}",
+        f"- pareto_log: {ParetoLog(state.run_id, root).path}",
     ]
+    if overshoot:
+        lines.append(
+            f"- budget_overshoot: {overshoot} eval row(s) beyond "
+            f"--max-iterations (in-flight lane evals; bounded by "
+            f"lanes x --acceptance-max-repetitions, pydanticaigepa-dec-msy)"
+        )
     if rows:
         best = max(rows, key=lambda row: row.mean_score)
         latest = rows[-1]
@@ -1160,6 +1186,38 @@ def continue_(
     _emit_status(
         state, outcomes=outcomes, final_report=final_path, final_report_text=final_text
     )
+
+
+@app.command("select")
+def select(
+    run_id: str | None = typer.Option(
+        None,
+        "--run-id",
+        help="Managed run id. Omit to use the latest run with a state file.",
+    ),
+) -> None:
+    """Commit one lockstep lane iteration: pick the winner and re-fan lanes.
+
+    Select is the single sequential authority for lane runs
+    (pydanticaigepa-spec-er3). It consumes the memoized lane verdicts (never
+    re-deriving them), invalidates stragglers, promotes the best accepted lane
+    to the run's best, journals every non-promoted lane before deleting its
+    branch, emits merge_opportunity for accepted lanes with disjoint diffs
+    (never auto-merges), enforces the evaluation budget (run_done + overshoot
+    in the final report), and — when budget remains — re-fans every lane onto
+    the new best with a fresh shared baseline and lane_ready events.
+
+    Select records phase progress (promote, journal, re-fan, re-baseline,
+    emit) in run state; a second invocation while one is in flight is
+    rejected, and an interrupted select resumes idempotently from the recorded
+    phase.
+
+    Exit codes: 0 selection committed; 1 not a lane run / not due / already
+    in flight / already done.
+    """
+    from .select import run_select
+
+    run_select(run_id)
 
 
 @app.command("status")

--- a/src/pydantic_ai_gepa/cli/run.py
+++ b/src/pydantic_ai_gepa/cli/run.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 import json
+import os
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -278,10 +279,25 @@ class RunState:
             ),
         )
 
-    def save(self) -> Path:
-        path = run_state_path(self.run_id)
+    def save(self, root: Path | None = None) -> Path:
+        path = run_state_path(self.run_id, root)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        # Atomic (tmpfile + os.replace): lane evals, select checkpoints, and
+        # operator verbs all write this file; a kill mid-write must never
+        # leave torn JSON for the resume logic to trip over.
+        import tempfile
+
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(self.to_dict(), handle, indent=2)
+                handle.write("\n")
+            os.replace(tmp_name, path)
+        except BaseException:
+            os.unlink(tmp_name)
+            raise
         return path
 
 

--- a/src/pydantic_ai_gepa/cli/select.py
+++ b/src/pydantic_ai_gepa/cli/select.py
@@ -1,0 +1,1120 @@
+"""`gepa run select` — lockstep multi-way selection and re-fan (spec-er3).
+
+Select is the single sequential authority that turns N lane verdicts into at
+most one promoted candidate, advances the run's best, teaches the journal what
+lost and why, and re-fans lanes for the next iteration
+(pydanticaigepa-task-vso).
+
+Phase model — recorded in run state as ``select_phase`` with resumption
+progress in ``select_context``; every phase checkpoints before the next
+begins, so a select killed mid-way resumes idempotently from the recorded
+phase on the next invocation:
+
+1. ``promote`` — invalidate stragglers (terminate the eval pid, journal the
+   partial result + diff summary, mark ``stalled``; pydanticaigepa-dec-4tw),
+   invalidate lanes whose candidate no longer descends from the frozen
+   baseline commit, pick the winner among the memoized ``accepted`` verdicts
+   (highest delta, ties broken by lane id order), promote the winner commit to
+   the run's best (the primary checkout is reset only when clean and still on
+   the old best — user work is never destroyed), journal the winner, and emit
+   ``merge_opportunity`` for accepted lane pairs with disjoint diffs (merging
+   itself is always delegated to the coding agent — never auto-merged).
+2. ``journal`` — every non-promoted resolved lane is journaled (diff summary,
+   verdict, delta, confidence) *before* its branch is deleted.
+3. ``refan`` — reset every lane worktree onto the new best on a fresh
+   ``gepa/lane/<lane>/<iteration>`` branch, delete the previous-iteration
+   branches (already journaled), and return lanes to ``paused_for_reflection``
+   with a bumped iteration and fresh lease epoch. The winner's branch is
+   deleted too once the primary checkout carries its commit; when the primary
+   could not be promoted (dirty or moved), the winner branch is kept so the
+   commit stays reachable.
+4. ``rebaseline`` — sample the next reflection minibatch and re-measure the
+   shared baseline once per iteration against the new best tree (baseline
+   evals are paid once per iteration, not once per lane).
+5. ``emit`` — write fresh reflection packets and emit ``lane_ready`` per lane.
+
+``finalize`` replaces re-fan when the pareto ledger reaches
+``--max-iterations``: lane-run budget enforcement lives at select, not
+per-eval (pydanticaigepa-dec-msy). The run is marked done, any overshoot
+(in-flight lane evals beyond the cap, bounded by N x
+``--acceptance-max-repetitions``) is recorded in the final report,
+``run_done`` is emitted, and lane worktrees are removed — a lane is re-fanned
+at select or removed when the run completes (spec-1do).
+
+Journal writes and event emissions carry dedup keys, so re-executing a phase
+after a kill is exactly-once. Lane verdicts are consumed from lane state —
+they are memoized by the lane eval processes and never re-derived here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Iterator
+
+import typer
+
+from .candidates import GitCandidateError, git_candidate_state
+from .eval import run_eval_once
+from .events import EventDraft, emit, list_events
+from .lanes import (
+    LaneState,
+    _git,
+    _pid_alive,
+    _resolve_lane_run,
+    create_lane_worktree,
+    lane_branch,
+    lane_worktree_path,
+    load_all_lane_states,
+    load_lane_state,
+    reaper_pass_for_run,
+    scan_lane_states,
+    write_packet,
+)
+from .layout import final_report_path, journal_path, run_dir, run_state_path
+from .runs import ParetoLog, utc_now_iso
+
+SELECT_PRODUCER_ID = "select"
+
+# Phase ordering (spec-er3). ``finalize`` is the budget-exhausted terminal
+# phase reached from ``journal`` instead of ``refan``.
+SELECT_PHASES = ("promote", "journal", "refan", "rebaseline", "emit", "finalize")
+
+_PID_TERM_GRACE_SECS = 5.0
+_PID_KILL_GRACE_SECS = 2.0
+
+
+# ----------------------------- helpers ----------------------------------
+
+
+def _save_state(state: Any, workspace_root: Path) -> None:
+    """Persist run state at the explicit workspace (never derived from cwd)."""
+    path = run_state_path(state.run_id, workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state.to_dict(), indent=2), encoding="utf-8")
+
+
+def _checkpoint(
+    state: Any, workspace_root: Path, phase: str | None, ctx: dict[str, Any] | None
+) -> Any:
+    """Record select phase progress; ``phase=None`` clears the in-flight marker."""
+    fresh = replace(
+        state,
+        select_phase=phase,
+        select_context=(dict(ctx) if ctx is not None else None),
+        updated_at=utc_now_iso(),
+    )
+    _save_state(fresh, workspace_root)
+    return fresh
+
+
+@contextmanager
+def _chdir(path: Path) -> Iterator[None]:
+    old = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def _load_comparison(lane_state: LaneState) -> dict[str, Any]:
+    if lane_state.comparison_path and Path(lane_state.comparison_path).exists():
+        data = json.loads(Path(lane_state.comparison_path).read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    return {}
+
+
+def _lane_outcome_journaled(
+    workspace_root: Path, run_id: str, lane: str, iteration: int
+) -> bool:
+    """Dedup key for journal write-back: one lane outcome per (run, lane, iteration)."""
+    path = journal_path(workspace_root)
+    if not path.exists():
+        return False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        row = json.loads(stripped)
+        if (
+            row.get("kind") == "lane_outcome"
+            and row.get("run_id") == run_id
+            and row.get("lane") == lane
+            and row.get("iteration") == iteration
+        ):
+            return True
+    return False
+
+
+def _journal_lane_outcome(workspace_root: Path, entry: dict[str, Any]) -> None:
+    """Append a lane-outcome journal entry unless already journaled (resume-safe)."""
+    if _lane_outcome_journaled(
+        workspace_root,
+        str(entry["run_id"]),
+        str(entry["lane"]),
+        int(entry["iteration"]),
+    ):
+        return
+    path = journal_path(workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _lane_outcome_entry(
+    run_id: str,
+    lane_state: LaneState,
+    *,
+    outcome: str,
+    diff_summary: str = "",
+    confidence: float | None = None,
+    reason: str | None = None,
+    untracked_paths: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    delta = lane_state.verdict_delta
+    verdict = lane_state.verdict or "none"
+    content = (
+        f"select {outcome}: lane {lane_state.lane} iteration "
+        f"{lane_state.iteration} verdict={verdict}"
+    )
+    if delta is not None:
+        content += f" delta={delta:+.4f}"
+    if reason:
+        content += f" ({reason})"
+    return {
+        "timestamp": utc_now_iso(),
+        "kind": "lane_outcome",
+        "strategy": "select",
+        "run_id": run_id,
+        "lane": lane_state.lane,
+        "iteration": lane_state.iteration,
+        "outcome": outcome,
+        "branch": lane_state.branch,
+        "candidate_sha": lane_state.candidate_sha,
+        "verdict": lane_state.verdict,
+        "delta": delta,
+        "confidence": confidence,
+        "eval_samples": list(lane_state.eval_samples),
+        "diff_summary": diff_summary,
+        "untracked_paths": list(untracked_paths),
+        "reason": reason,
+        "content": content,
+    }
+
+
+def _diff_stat(workspace_root: Path, base_sha: str, head_sha: str) -> str:
+    try:
+        return _git(workspace_root, "diff", "--stat", base_sha, head_sha)
+    except Exception:  # noqa: BLE001 — missing refs on hand-crafted lane state
+        return ""
+
+
+def _changed_files(workspace_root: Path, base_sha: str, head_sha: str) -> set[str]:
+    try:
+        out = _git(workspace_root, "diff", "--name-only", base_sha, head_sha)
+    except Exception:  # noqa: BLE001
+        return set()
+    return {line for line in out.splitlines() if line}
+
+
+def _terminate_eval_pid(pid: int, *, lane: str) -> None:
+    """Terminate a straggler's eval process: SIGTERM, then SIGKILL (dec-4tw)."""
+    os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + _PID_TERM_GRACE_SECS
+    while _pid_alive(pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if _pid_alive(pid):
+        os.kill(pid, signal.SIGKILL)
+        deadline = time.monotonic() + _PID_KILL_GRACE_SECS
+        while _pid_alive(pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+    if _pid_alive(pid):
+        typer.echo(
+            f"Lane {lane} eval pid {pid} survived SIGKILL; refusing to "
+            "continue select while a straggler eval is alive.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
+def _mark_stalled(
+    workspace_root: Path, run_id: str, lane_state: LaneState
+) -> LaneState:
+    fresh = LaneState(
+        **{
+            **lane_state.to_dict(),
+            "status": "stalled",
+            "eval_pid": None,
+            "heartbeat_at": None,
+            "updated_at": utc_now_iso(),
+        }
+    )
+    fresh.save(workspace_root, run_id)
+    return fresh
+
+
+def _invalidate_straggler(
+    workspace_root: Path, state: Any, lane_state: LaneState, *, reason: str
+) -> None:
+    """Invalidate a lane that was not resolved when select ran (dec-4tw).
+
+    The eval process is terminated, the partial result and diff summary are
+    journaled, and the lane is marked ``stalled``. A straggler is never
+    compared against any baseline and never promoted. Uncommitted lane work is
+    recorded (diff stat + untracked paths) before the re-fan resets it.
+    """
+    run_id = state.run_id
+    pid = lane_state.eval_pid
+    if pid is not None and _pid_alive(pid):
+        typer.echo(f"Terminating straggler lane {lane_state.lane} eval (pid {pid}).")
+        _terminate_eval_pid(pid, lane=lane_state.lane)
+
+    diff_summary = ""
+    untracked: tuple[str, ...] = ()
+    baseline_sha = state.reflection_baseline_commit_sha
+    worktree = Path(lane_state.worktree_path) if lane_state.worktree_path else None
+    if worktree is not None and worktree.exists() and baseline_sha:
+        try:
+            # Working-tree diff against the frozen baseline captures both the
+            # committed lane work and uncommitted tracked edits.
+            diff_summary = _git(worktree, "diff", "--stat", baseline_sha)
+            untracked = tuple(
+                line[3:]
+                for line in _git(worktree, "status", "--porcelain").splitlines()
+                if line.startswith("?? ")
+            )
+        except Exception:  # noqa: BLE001 — best-effort record before reset
+            diff_summary = ""
+            untracked = ()
+    _journal_lane_outcome(
+        workspace_root,
+        _lane_outcome_entry(
+            run_id,
+            lane_state,
+            outcome="straggler",
+            diff_summary=diff_summary,
+            reason=reason,
+            untracked_paths=untracked,
+        ),
+    )
+    _mark_stalled(workspace_root, run_id, lane_state)
+
+
+def _invalidate_cross_baseline(
+    workspace_root: Path, state: Any, lane_state: LaneState
+) -> None:
+    """Invalidate a lane whose branch point is not the frozen baseline commit.
+
+    Lanes are never compared against baselines from a different branch point;
+    the lane is marked ``stalled``, never silently compared (spec-er3).
+    """
+    run_id = state.run_id
+    pid = lane_state.eval_pid
+    if pid is not None and _pid_alive(pid):
+        _terminate_eval_pid(pid, lane=lane_state.lane)
+    baseline_sha = str(state.reflection_baseline_commit_sha)
+    diff_summary = (
+        _diff_stat(workspace_root, baseline_sha, lane_state.candidate_sha)
+        if lane_state.candidate_sha
+        else ""
+    )
+    _journal_lane_outcome(
+        workspace_root,
+        _lane_outcome_entry(
+            run_id,
+            lane_state,
+            outcome="invalidated",
+            diff_summary=diff_summary,
+            confidence=_load_comparison(lane_state).get("confidence"),
+            reason=(
+                "candidate commit does not descend from the frozen baseline "
+                f"commit {baseline_sha}; never compared or promoted"
+            ),
+        ),
+    )
+    _mark_stalled(workspace_root, run_id, lane_state)
+
+
+def _is_ancestor(workspace_root: Path, ancestor_sha: str, head_sha: str) -> bool:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(workspace_root),
+            "merge-base",
+            "--is-ancestor",
+            ancestor_sha,
+            head_sha,
+        ],
+        capture_output=True,
+    )
+    return completed.returncode == 0
+
+
+def _primary_checkout_state(workspace_root: Path) -> tuple[str, bool]:
+    """Return (HEAD sha, dirty) for the primary checkout.
+
+    Dirtiness reuses git candidate identity exclusions so run bookkeeping —
+    the run ledger, lane worktrees, and the append-only reflection ledger
+    (journal.jsonl, which select itself appends to every iteration) — never
+    counts as user changes.
+    """
+    from .lanes import worktrees_root
+    from .layout import runs_dir
+
+    head = _git(workspace_root, "rev-parse", "HEAD")
+    try:
+        candidate = git_candidate_state(
+            workspace_root,
+            exclude_paths=[
+                runs_dir(workspace_root),
+                worktrees_root(workspace_root),
+                journal_path(workspace_root),
+            ],
+        )
+        dirty = candidate.dirty
+    except GitCandidateError:
+        dirty = True
+    return head, dirty
+
+
+def _reset_primary_to(workspace_root: Path, commit_sha: str) -> None:
+    """Fast-forward the primary checkout to ``commit_sha``.
+
+    The reflection ledger is append-only run bookkeeping that lane commits
+    never carry, so a plain ``reset --hard`` would revert a tracked
+    journal.jsonl to the winner commit's content and destroy the write-back
+    select just performed (and every uncommitted entry before it). The
+    journal content is preserved across the reset.
+    """
+    journal_file = journal_path(workspace_root)
+    journal_bytes = journal_file.read_bytes() if journal_file.exists() else None
+    _git(workspace_root, "reset", "--hard", commit_sha)
+    if journal_bytes is not None:
+        journal_file.write_bytes(journal_bytes)
+
+
+def _emit_merge_opportunities(
+    workspace_root: Path,
+    state: Any,
+    ctx: dict[str, Any],
+    accepted: list[LaneState],
+) -> None:
+    """Emit merge_opportunity for accepted lane pairs with disjoint diffs.
+
+    Auto-merge is prohibited (spec-er3): the event surfaces the branch pair
+    plus a diff-stat path for the orchestrator to resolve with a real merge.
+    """
+    run_id = state.run_id
+    baseline_sha = str(state.reflection_baseline_commit_sha)
+    file_sets = {
+        lane_state.lane: _changed_files(
+            workspace_root, baseline_sha, str(lane_state.candidate_sha)
+        )
+        for lane_state in accepted
+        if lane_state.candidate_sha
+    }
+    existing = list_events(run_id, workspace_root)
+    pairs: list[list[str]] = []
+    for first, second in combinations(
+        sorted(accepted, key=lambda lane_state: lane_state.lane), 2
+    ):
+        files_a = file_sets.get(first.lane, set())
+        files_b = file_sets.get(second.lane, set())
+        if not files_a or not files_b or not files_a.isdisjoint(files_b):
+            continue
+        merge_dir = run_dir(run_id, workspace_root) / "merge_opportunities"
+        merge_dir.mkdir(parents=True, exist_ok=True)
+        stat_path = merge_dir / f"{first.lane}--{second.lane}.diffstat"
+        stat_path.write_text(
+            f"# {first.lane} ({first.branch}) vs baseline {baseline_sha}\n"
+            + _diff_stat(workspace_root, baseline_sha, str(first.candidate_sha))
+            + f"\n\n# {second.lane} ({second.branch}) vs baseline {baseline_sha}\n"
+            + _diff_stat(workspace_root, baseline_sha, str(second.candidate_sha))
+            + "\n",
+            encoding="utf-8",
+        )
+        duplicate = any(
+            event.type == "merge_opportunity"
+            and event.payload.get("lane_a") == first.lane
+            and event.payload.get("lane_b") == second.lane
+            and event.payload.get("branch_a") == first.branch
+            and event.payload.get("branch_b") == second.branch
+            for event in existing
+        )
+        if not duplicate:
+            emit(
+                run_id,
+                SELECT_PRODUCER_ID,
+                EventDraft(
+                    type="merge_opportunity",
+                    lane=None,
+                    payload={
+                        "lane_a": first.lane,
+                        "lane_b": second.lane,
+                        "branch_a": str(first.branch),
+                        "branch_b": str(second.branch),
+                        "diff_stat_path": str(stat_path),
+                    },
+                ),
+                root=workspace_root,
+            )
+        pairs.append([first.lane, second.lane])
+        typer.echo(
+            f"merge_opportunity: {first.lane} and {second.lane} touched disjoint "
+            f"files; resolve with a real git merge (never auto-merged). "
+            f"Diff stat: {stat_path}"
+        )
+    ctx["merge_pairs"] = pairs
+
+
+# ----------------------------- phases -----------------------------------
+
+
+def _phase_promote(
+    workspace_root: Path, state: Any, ctx: dict[str, Any]
+) -> tuple[Any, dict[str, Any], str]:
+    """Invalidate stragglers/cross-baseline lanes, pick + promote the winner."""
+    run_id = state.run_id
+    baseline_sha = state.reflection_baseline_commit_sha
+    if not baseline_sha:
+        typer.echo(
+            f"Run {run_id} has no frozen reflection baseline commit; cannot select.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    lane_states = load_all_lane_states(workspace_root, run_id)
+
+    # 1. Straggler invalidation (dec-4tw): anything not awaiting_selection when
+    #    select runs is terminated, journaled, and stalled — never compared,
+    #    never promoted. Idempotent: journaled lanes dedup, stalled markings
+    #    repeat harmlessly.
+    stragglers: list[str] = []
+    for lane_state in lane_states:
+        if lane_state.status == "awaiting_selection":
+            continue
+        _invalidate_straggler(
+            workspace_root,
+            state,
+            lane_state,
+            reason="lane was not resolved when select ran",
+        )
+        stragglers.append(lane_state.lane)
+
+    # 2. Frozen-baseline consistency: a lane whose candidate commit no longer
+    #    descends from the frozen branch point is invalidated, never compared.
+    invalidated: list[str] = []
+    valid: list[LaneState] = []
+    for lane_state in lane_states:
+        if lane_state.status != "awaiting_selection":
+            continue
+        candidate_sha = lane_state.candidate_sha
+        if candidate_sha and _is_ancestor(
+            workspace_root, str(baseline_sha), candidate_sha
+        ):
+            valid.append(lane_state)
+        else:
+            _invalidate_cross_baseline(workspace_root, state, lane_state)
+            invalidated.append(lane_state.lane)
+
+    # 3. Winner selection, strategy `best`: highest memoized delta among
+    #    accepted lanes; ties break by lane id order. Verdicts are consumed
+    #    from lane state (memoized by the lane eval) — never re-derived here.
+    accepted = [lane_state for lane_state in valid if lane_state.verdict == "accepted"]
+    winner: LaneState | None = None
+    if accepted:
+        winner = sorted(
+            accepted,
+            key=lambda lane_state: (
+                -(lane_state.verdict_delta or 0.0),
+                lane_state.lane,
+            ),
+        )[0]
+    losers = [lane_state.lane for lane_state in valid if lane_state is not winner]
+
+    ctx.update(
+        {
+            "baseline_sha": str(baseline_sha),
+            "winner": winner.lane if winner else None,
+            "winner_branch": winner.branch if winner else None,
+            "winner_commit_sha": winner.candidate_sha if winner else None,
+            "losers": losers,
+            "stragglers": stragglers,
+            "invalidated": invalidated,
+            "new_lane_iteration": max(
+                (lane_state.iteration for lane_state in lane_states), default=0
+            )
+            + 1,
+        }
+    )
+
+    if winner is None:
+        typer.echo(
+            "No lane was accepted; no promotion. All resolved lanes are "
+            "journaled as losers and lanes re-fan onto the current best."
+        )
+        ctx["primary_promoted"] = False
+        return state, ctx, "journal"
+
+    # 4. Promotion: the winner's commit becomes the run's best. The primary
+    #    checkout is fast-forwarded only when clean and still on the old best;
+    #    otherwise promotion happens in run state only (user work is never
+    #    destroyed).
+    comparison = _load_comparison(winner)
+    winner_mean = comparison.get("candidate_mean")
+    if winner_mean is None and winner.eval_samples:
+        winner_mean = sum(winner.eval_samples) / len(winner.eval_samples)
+    winner_candidate_id = (
+        comparison.get("candidate_id") or str(winner.candidate_sha)[:12]
+    )
+    winner_sha = str(winner.candidate_sha)
+
+    _journal_lane_outcome(
+        workspace_root,
+        _lane_outcome_entry(
+            run_id,
+            winner,
+            outcome="promoted",
+            diff_summary=_diff_stat(workspace_root, str(baseline_sha), winner_sha),
+            confidence=comparison.get("confidence"),
+        ),
+    )
+
+    old_best = state.best_commit_sha
+    primary_head, primary_dirty = _primary_checkout_state(workspace_root)
+    primary_promoted = False
+    if primary_head == winner_sha:
+        primary_promoted = True  # already at the winner (resume after reset)
+    elif primary_dirty:
+        typer.echo(
+            "Warning: primary checkout is dirty; promoted the winner in run "
+            "state only — uncommitted work is preserved. Restore with: "
+            f"git checkout {winner_sha}",
+            err=True,
+        )
+    elif old_best and primary_head != old_best:
+        typer.echo(
+            f"Warning: primary checkout HEAD ({primary_head[:12]}) is not the "
+            f"run's previous best ({str(old_best)[:12]}); promoted the winner "
+            f"in run state only. Restore with: git checkout {winner_sha}",
+            err=True,
+        )
+    else:
+        _reset_primary_to(workspace_root, winner_sha)
+        primary_promoted = True
+
+    state = replace(
+        state,
+        best_candidate_id=str(winner_candidate_id),
+        best_commit_sha=winner_sha,
+        best_mean_score=(
+            float(winner_mean) if winner_mean is not None else state.best_mean_score
+        ),
+    )
+    ctx["primary_promoted"] = primary_promoted
+    ctx["winner_mean"] = winner_mean
+    typer.echo(
+        f"Promoted lane {winner.lane} (delta {(winner.verdict_delta or 0.0):+.4f}) "
+        f"as the run's best: {winner_sha[:12]}"
+        + ("" if primary_promoted else " (run state only; primary untouched)")
+    )
+
+    # 5. merge_opportunity for accepted lanes with disjoint diffs.
+    if len(accepted) >= 2:
+        _emit_merge_opportunities(workspace_root, state, ctx, accepted)
+    else:
+        ctx["merge_pairs"] = []
+
+    return state, ctx, "journal"
+
+
+def _phase_journal(
+    workspace_root: Path, state: Any, ctx: dict[str, Any]
+) -> tuple[Any, dict[str, Any], str]:
+    """Journal every non-promoted resolved lane before its branch is deleted."""
+    run_id = state.run_id
+    baseline_sha = str(ctx.get("baseline_sha") or state.reflection_baseline_commit_sha)
+    journaled: list[str] = list(ctx.get("journaled_lanes", []))
+    for lane in list(ctx.get("losers", [])):
+        if lane in journaled:
+            continue
+        lane_state = load_lane_state(workspace_root, run_id, lane)
+        comparison = _load_comparison(lane_state)
+        diff_summary = (
+            _diff_stat(workspace_root, baseline_sha, lane_state.candidate_sha)
+            if lane_state.candidate_sha
+            else ""
+        )
+        _journal_lane_outcome(
+            workspace_root,
+            _lane_outcome_entry(
+                run_id,
+                lane_state,
+                outcome="loser",
+                diff_summary=diff_summary,
+                confidence=comparison.get("confidence"),
+                reason="not promoted",
+            ),
+        )
+        journaled.append(lane)
+        ctx["journaled_lanes"] = journaled
+        # Per-lane checkpoint: a kill here resumes with the next loser.
+        state = _checkpoint(state, workspace_root, "journal", ctx)
+
+    # Budget enforcement (dec-msy): the pareto ledger is the sole budget
+    # authority; the stop condition for lane runs is checked here, not per-eval.
+    rows = ParetoLog(run_id, workspace_root).count_rows()
+    ctx["budget_rows"] = rows
+    ctx["overshoot"] = max(0, rows - state.max_iterations)
+    if rows >= state.max_iterations:
+        return state, ctx, "finalize"
+    return state, ctx, "refan"
+
+
+def _keep_branch(ctx: dict[str, Any]) -> str | None:
+    """The winner's branch survives only while it is the commit's sole ref."""
+    if ctx.get("winner") and not ctx.get("primary_promoted"):
+        return ctx.get("winner_branch")
+    return None
+
+
+def _delete_branch(workspace_root: Path, branch: str) -> None:
+    try:
+        _git(workspace_root, "branch", "-D", branch)
+    except subprocess.CalledProcessError:
+        pass  # already deleted (resume)
+
+
+def _refan_lane(
+    workspace_root: Path,
+    state: Any,
+    lane_state: LaneState,
+    *,
+    new_branch: str,
+    new_iteration: int,
+    new_best: str,
+    keep_branch: str | None,
+) -> LaneState:
+    """Reset one lane worktree onto the new best with a fresh branch.
+
+    Idempotent: a lane already on ``new_branch`` at ``new_best`` (resume after
+    a mid-phase kill) is left alone; its state is still rewritten below.
+    """
+    run_id = state.run_id
+    old_branch = lane_state.branch
+    worktree = (
+        Path(lane_state.worktree_path)
+        if lane_state.worktree_path
+        else lane_worktree_path(workspace_root, lane_state.lane)
+    )
+    if worktree.exists():
+        on_new_branch = (
+            _git(worktree, "rev-parse", "--abbrev-ref", "HEAD") == new_branch
+            and _git(worktree, "rev-parse", "HEAD") == new_best
+        )
+        if not on_new_branch:
+            # Uncommitted work was journaled during invalidation/journaling;
+            # resetting here never destroys unrecorded diffs (spec-er3).
+            _git(worktree, "reset", "--hard", "HEAD")
+            _git(worktree, "clean", "-fd")
+            _git(workspace_root, "branch", "-f", new_branch, new_best)
+            _git(worktree, "checkout", new_branch)
+    else:
+        # Repair a missing worktree from scratch (create_lane_worktree cuts
+        # the fresh branch from the new best).
+        path, _ = create_lane_worktree(
+            workspace_root, run_id, lane_state.lane, new_iteration, new_best
+        )
+        worktree = path
+    if old_branch and old_branch != new_branch and old_branch != keep_branch:
+        _delete_branch(workspace_root, old_branch)
+    return LaneState(
+        **{
+            **lane_state.to_dict(),
+            "status": "paused_for_reflection",
+            "iteration": new_iteration,
+            "branch": new_branch,
+            "worktree_path": str(worktree),
+            "packet_path": None,
+            "lease_epoch": lane_state.lease_epoch + 1,
+            "lease_expires_at": None,
+            "candidate_sha": None,
+            "eval_samples": (),
+            "verdict": None,
+            "verdict_delta": None,
+            "comparison_path": None,
+            "eval_pid": None,
+            "heartbeat_at": None,
+            "updated_at": utc_now_iso(),
+        }
+    )
+
+
+def _phase_refan(
+    workspace_root: Path, state: Any, ctx: dict[str, Any]
+) -> tuple[Any, dict[str, Any], str]:
+    """Reset all lanes onto the new best and delete journaled branches."""
+    run_id = state.run_id
+    new_best = state.best_commit_sha
+    if not new_best:
+        typer.echo(
+            f"Run {run_id} has no best commit to re-fan onto; cannot continue.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    new_iteration = int(ctx.get("new_lane_iteration", 0)) or 1
+    keep_branch = _keep_branch(ctx)
+    refanned: list[str] = list(ctx.get("refanned_lanes", []))
+    for lane_state in load_all_lane_states(workspace_root, run_id):
+        if lane_state.lane in refanned:
+            continue
+        new_branch = lane_branch(lane_state.lane, new_iteration)
+        fresh = _refan_lane(
+            workspace_root,
+            state,
+            lane_state,
+            new_branch=new_branch,
+            new_iteration=new_iteration,
+            new_best=str(new_best),
+            keep_branch=keep_branch,
+        )
+        fresh.save(workspace_root, run_id)
+        refanned.append(lane_state.lane)
+        ctx["refanned_lanes"] = refanned
+        state = _checkpoint(state, workspace_root, "refan", ctx)
+        typer.echo(
+            f"Lane {lane_state.lane} re-fanned onto {str(new_best)[:12]} "
+            f"(branch {new_branch}, iteration {new_iteration})."
+        )
+    return state, ctx, "rebaseline"
+
+
+def _phase_rebaseline(
+    workspace_root: Path, state: Any, ctx: dict[str, Any]
+) -> tuple[Any, dict[str, Any], str]:
+    """Sample the next minibatch and re-measure the shared baseline once.
+
+    The baseline is measured against the new best tree: the primary checkout
+    when it carries the new best, otherwise the first lane's freshly re-fanned
+    worktree (identical content). Baseline evals are paid once per iteration,
+    not once per lane (spec-er3).
+    """
+    from .run import _mark_reflection_pause, _with_last_outcome, _with_timestamp
+
+    run_id = state.run_id
+    if ctx.get("baseline_captured"):
+        return state, ctx, "emit"
+
+    new_best = str(state.best_commit_sha)
+    primary_head, primary_dirty = _primary_checkout_state(workspace_root)
+    if primary_head == new_best and not primary_dirty:
+        baseline_root = workspace_root
+    else:
+        lane_states = load_all_lane_states(workspace_root, run_id)
+        baseline_root = Path(str(lane_states[0].worktree_path))
+        typer.echo(
+            "Primary checkout does not carry the new best; measuring the "
+            f"shared baseline in {baseline_root} (same commit).",
+            err=True,
+        )
+
+    ledger = ParetoLog(run_id, workspace_root)
+    remaining = state.max_iterations - ledger.count_rows()
+    affordable_repetitions = max(1, (remaining + 1) // 2)
+    target_repetitions = min(state.acceptance_max_repetitions, affordable_repetitions)
+
+    outcomes: list[Any] = []
+    with _chdir(baseline_root):
+        first = run_eval_once(
+            candidate_file=None,
+            minibatch_id=None,
+            size=state.size,
+            seed=state.seed,
+            epoch=state.next_epoch,
+            run_id=run_id,
+            concurrency=state.concurrency,
+            max_iterations=state.max_iterations,
+            threshold=state.threshold,
+            capture_traces=True,
+            candidate_source=state.candidate_source,
+            lane=None,
+            candidate_root=baseline_root,
+            workspace_root=workspace_root,
+        )
+        state = _with_timestamp(state, next_epoch=state.next_epoch + 1)
+        state = _with_last_outcome(state, first)
+        outcomes.append(first)
+        expected_candidate_id = str(first.summary["candidate_id"])
+        minibatch_id = str(first.summary["minibatch_id"])
+        while len(outcomes) < target_repetitions:
+            outcome = run_eval_once(
+                candidate_file=None,
+                minibatch_id=minibatch_id,
+                size=state.size,
+                seed=state.seed,
+                epoch=state.next_epoch,
+                run_id=run_id,
+                concurrency=state.concurrency,
+                max_iterations=state.max_iterations,
+                threshold=state.threshold,
+                capture_traces=True,
+                candidate_source=state.candidate_source,
+                lane=None,
+                candidate_root=baseline_root,
+                workspace_root=workspace_root,
+            )
+            if str(outcome.summary["candidate_id"]) != expected_candidate_id:
+                typer.echo(
+                    "The baseline candidate changed while collecting repeated "
+                    "evaluations; refusing to compare mixed candidates.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            state = _with_last_outcome(state, outcome)
+            outcomes.append(outcome)
+
+    state = _mark_reflection_pause(state, outcomes)
+    # Lane runs stay "running" — lanes carry the reflection pause.
+    state = replace(state, status="running")
+    ctx["baseline_captured"] = True
+    # Mid-phase checkpoint so a kill after capture never re-measures.
+    state = _checkpoint(state, workspace_root, "rebaseline", ctx)
+    typer.echo(
+        f"Shared baseline re-measured at {new_best[:12]} "
+        f"(samples {list(state.reflection_baseline_samples)})."
+    )
+    return state, ctx, "emit"
+
+
+def _phase_emit(
+    workspace_root: Path, state: Any, ctx: dict[str, Any]
+) -> tuple[Any, dict[str, Any], str | None]:
+    """Write fresh packets and emit lane_ready once per lane."""
+    run_id = state.run_id
+    started_ms = int(ctx.get("started_ms", 0))
+    existing = list_events(run_id, workspace_root)
+    emitted: list[str] = list(ctx.get("emitted_lanes", []))
+    for lane_state in load_all_lane_states(workspace_root, run_id):
+        if lane_state.lane in emitted:
+            continue
+        worktree = Path(str(lane_state.worktree_path))
+        packet_path = write_packet(
+            workspace_root,
+            state,
+            lane_state.lane,
+            lane_state.iteration,
+            worktree,
+            str(lane_state.branch),
+        )
+        fresh = LaneState(
+            **{
+                **lane_state.to_dict(),
+                "packet_path": str(packet_path),
+                "updated_at": utc_now_iso(),
+            }
+        )
+        fresh.save(workspace_root, run_id)
+        duplicate = any(
+            event.type == "lane_ready"
+            and event.lane == lane_state.lane
+            and int(event.id.split("-", 1)[0]) >= started_ms
+            for event in existing
+        )
+        if not duplicate:
+            emit(
+                run_id,
+                SELECT_PRODUCER_ID,
+                EventDraft(
+                    type="lane_ready",
+                    lane=lane_state.lane,
+                    payload={
+                        "packet_path": str(packet_path),
+                        "worktree_path": str(worktree),
+                    },
+                ),
+                root=workspace_root,
+            )
+        emitted.append(lane_state.lane)
+        ctx["emitted_lanes"] = emitted
+        state = _checkpoint(state, workspace_root, "emit", ctx)
+    return state, ctx, None
+
+
+def _phase_finalize(
+    workspace_root: Path, state: Any, ctx: dict[str, Any]
+) -> tuple[Any, dict[str, Any], str | None]:
+    """Budget exhausted: mark done, record overshoot, emit run_done.
+
+    Lanes are removed when the run completes (spec-1do): worktrees are removed
+    and lane branches deleted (all journaled by now) — except the winner's
+    branch when the primary checkout could not carry its commit.
+    """
+    from .run import _write_final_report
+
+    run_id = state.run_id
+    rows = ParetoLog(run_id, workspace_root).count_rows()
+    overshoot = max(0, rows - state.max_iterations)
+    state = replace(state, iterations=rows, status="done")
+
+    keep_branch = _keep_branch(ctx)
+    _git(workspace_root, "worktree", "prune")
+    for lane_state in load_all_lane_states(workspace_root, run_id):
+        worktree = Path(lane_state.worktree_path) if lane_state.worktree_path else None
+        if worktree is not None and worktree.exists():
+            try:
+                _git(workspace_root, "worktree", "remove", "--force", str(worktree))
+            except subprocess.CalledProcessError:
+                pass
+        branch = lane_state.branch
+        if branch and branch != keep_branch:
+            _delete_branch(workspace_root, branch)
+
+    final_path, final_text = _write_final_report(
+        state, overshoot=overshoot, root=workspace_root
+    )
+    duplicate = any(
+        event.type == "run_done" for event in list_events(run_id, workspace_root)
+    )
+    if not duplicate:
+        emit(
+            run_id,
+            SELECT_PRODUCER_ID,
+            EventDraft(
+                type="run_done",
+                lane=None,
+                payload={"final_report_path": str(final_path)},
+            ),
+            root=workspace_root,
+        )
+    typer.echo(
+        f"Evaluation budget exhausted ({rows}/{state.max_iterations} rows"
+        + (f", overshoot {overshoot}" if overshoot else "")
+        + "); run marked done."
+    )
+    typer.echo(final_text.rstrip())
+    return state, ctx, None
+
+
+# ----------------------------- entry point -------------------------------
+
+
+def _preselect_check(workspace_root: Path, state: Any) -> None:
+    """Fresh-invocation preconditions: reaper pass + selection due-ness."""
+    run_id = state.run_id
+    reaper_pass_for_run(workspace_root, state)
+    scan = scan_lane_states(workspace_root, run_id, state)
+    lane_states = load_all_lane_states(workspace_root, run_id)
+    resolved = [s for s in lane_states if s.status == "awaiting_selection"]
+    unresolved = [s for s in lane_states if s.status != "awaiting_selection"]
+    if not resolved:
+        typer.echo(
+            f"Run {run_id} has no lanes in awaiting_selection; nothing to "
+            "select. Drive lanes with `gepa lane continue` first.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if unresolved and scan.selection_due is None:
+        names = ", ".join(s.lane for s in unresolved)
+        typer.echo(
+            f"Selection is not due: lanes {names} are still in flight and the "
+            "straggler timeout has not elapsed. Wait for `selection_due` "
+            "(`gepa next --wait`) or resolve the lanes.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
+def run_select(run_id: str | None) -> Any:
+    """Execute `gepa run select` (see module docstring for the phase model)."""
+    workspace_root, run_state = _resolve_lane_run(run_id)
+    if run_state.status == "done":
+        typer.echo(
+            f"Run {run_state.run_id} is done; there is nothing to select.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    state = run_state
+    if state.select_phase is None:
+        _preselect_check(workspace_root, state)
+        ctx: dict[str, Any] = {
+            "pid": os.getpid(),
+            "started_ms": int(time.time() * 1000),
+        }
+        state = _checkpoint(state, workspace_root, "promote", ctx)
+        phase: str | None = "promote"
+    else:
+        phase = state.select_phase
+        ctx = dict(state.select_context or {})
+        pid = ctx.get("pid")
+        if isinstance(pid, int) and pid != os.getpid() and _pid_alive(pid):
+            typer.echo(
+                f"Select already in flight for run {state.run_id} (phase "
+                f"{phase!r}, pid {pid}); a second concurrent select is "
+                "rejected (spec-er3).",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        typer.echo(
+            f"Resuming select for run {state.run_id} from phase {phase!r} "
+            "(recorded pid is this process or no longer alive)."
+        )
+
+    handlers = {
+        "promote": _phase_promote,
+        "journal": _phase_journal,
+        "refan": _phase_refan,
+        "rebaseline": _phase_rebaseline,
+        "emit": _phase_emit,
+        "finalize": _phase_finalize,
+    }
+    while phase is not None:
+        handler = handlers.get(phase)
+        if handler is None:
+            typer.echo(
+                f"Run {state.run_id} has an unknown select phase {phase!r}; "
+                "refusing to resume. Inspect the run state manually.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        state, ctx, next_phase = handler(workspace_root, state, ctx)
+        state = _checkpoint(
+            state, workspace_root, next_phase, ctx if next_phase else None
+        )
+        phase = next_phase
+
+    winner = ctx.get("winner")
+    if state.status == "done":
+        typer.echo(f"Select complete: run {state.run_id} is done.")
+    elif winner:
+        typer.echo(
+            f"Select complete: promoted {winner}; lanes re-fanned for "
+            f"iteration {ctx.get('new_lane_iteration')}."
+        )
+    else:
+        typer.echo("Select complete: no promotion; lanes re-fanned.")
+
+    from .run import _public_state
+
+    final_path = (
+        final_report_path(state.run_id, workspace_root)
+        if state.status == "done"
+        else None
+    )
+    typer.echo(
+        json.dumps({"run": _public_state(state, outcomes=[], final_report=final_path)})
+    )
+    return state
+
+
+__all__ = ["run_select"]

--- a/src/pydantic_ai_gepa/cli/select.py
+++ b/src/pydantic_ai_gepa/cli/select.py
@@ -95,10 +95,26 @@ _PID_KILL_GRACE_SECS = 2.0
 
 
 def _save_state(state: Any, workspace_root: Path) -> None:
-    """Persist run state at the explicit workspace (never derived from cwd)."""
+    """Persist run state at the explicit workspace (never derived from cwd).
+
+    Atomic (tmpfile + os.replace): select's entire idempotent-resume contract
+    rests on this file, so a kill mid-write must never leave torn JSON.
+    """
+    import tempfile
+
     path = run_state_path(state.run_id, workspace_root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state.to_dict(), indent=2), encoding="utf-8")
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(state.to_dict(), handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        os.unlink(tmp_name)
+        raise
 
 
 def _checkpoint(
@@ -274,7 +290,10 @@ def _invalidate_straggler(
     """
     run_id = state.run_id
     pid = lane_state.eval_pid
-    if pid is not None and _pid_alive(pid):
+    # Only signal when the lane claims to be mid-eval: a stale pid on a lane
+    # in any other status may have been recycled by the OS onto an unrelated
+    # process, and killing by bare number must never hit an innocent owner.
+    if pid is not None and lane_state.status == "evaluating" and _pid_alive(pid):
         typer.echo(f"Terminating straggler lane {lane_state.lane} eval (pid {pid}).")
         _terminate_eval_pid(pid, lane=lane_state.lane)
 
@@ -319,7 +338,7 @@ def _invalidate_cross_baseline(
     """
     run_id = state.run_id
     pid = lane_state.eval_pid
-    if pid is not None and _pid_alive(pid):
+    if pid is not None and lane_state.status == "evaluating" and _pid_alive(pid):
         _terminate_eval_pid(pid, lane=lane_state.lane)
     baseline_sha = str(state.reflection_baseline_commit_sha)
     diff_summary = (
@@ -468,7 +487,13 @@ def _emit_merge_opportunities(
                 ),
                 root=workspace_root,
             )
-        pairs.append([first.lane, second.lane])
+        pairs.append(
+            {
+                "lanes": [first.lane, second.lane],
+                "branches": [str(first.branch), str(second.branch)],
+                "shas": [str(first.candidate_sha), str(second.candidate_sha)],
+            }
+        )
         typer.echo(
             f"merge_opportunity: {first.lane} and {second.lane} touched disjoint "
             f"files; resolve with a real git merge (never auto-merged). "
@@ -623,6 +648,11 @@ def _phase_promote(
     )
     ctx["primary_promoted"] = primary_promoted
     ctx["winner_mean"] = winner_mean
+    # Checkpoint immediately after the promotion decision: the recorded phase
+    # state must always be a prefix of externally visible side effects
+    # (primary reset, journal entry), so a crash here never leaves the
+    # on-disk ctx claiming primary_promoted=False for a reset that happened.
+    state = _checkpoint(state, workspace_root, "promote", ctx)
     typer.echo(
         f"Promoted lane {winner.lane} (delta {(winner.verdict_delta or 0.0):+.4f}) "
         f"as the run's best: {winner_sha[:12]}"
@@ -676,16 +706,61 @@ def _phase_journal(
     rows = ParetoLog(run_id, workspace_root).count_rows()
     ctx["budget_rows"] = rows
     ctx["overshoot"] = max(0, rows - state.max_iterations)
+    overshoot_bound = state.lanes * state.acceptance_max_repetitions
+    if ctx["overshoot"] > overshoot_bound:
+        typer.echo(
+            f"Warning: budget overshoot {ctx['overshoot']} exceeds the "
+            f"lockstep bound {overshoot_bound} (lanes x acceptance "
+            "max-repetitions); investigate eval accounting.",
+            err=True,
+        )
+    # budget_low early warning (dec-d0d): emitted once per iteration while
+    # remaining budget is below lanes x acceptance max-repetitions.
+    remaining = state.max_iterations - rows
+    if 0 < remaining < overshoot_bound:
+        existing = list_events(run_id, workspace_root)
+        already = any(
+            event.type == "budget_low"
+            and event.payload.get("remaining_evals") == remaining
+            for event in existing
+        )
+        if not already:
+            emit(
+                run_id,
+                SELECT_PRODUCER_ID,
+                EventDraft(
+                    type="budget_low",
+                    lane=None,
+                    payload={"remaining_evals": remaining},
+                ),
+                root=workspace_root,
+            )
+            typer.echo(
+                f"budget_low: {remaining} evals remain (threshold {overshoot_bound})."
+            )
     if rows >= state.max_iterations:
         return state, ctx, "finalize"
     return state, ctx, "refan"
 
 
-def _keep_branch(ctx: dict[str, Any]) -> str | None:
-    """The winner's branch survives only while it is the commit's sole ref."""
+def _keep_branches(ctx: dict[str, Any]) -> frozenset[str]:
+    """Branches that survive re-fan deletion.
+
+    The winner's branch survives while it is the commit's sole ref (primary
+    not promoted), and every merge-opportunity branch pair survives until the
+    next select — the event names branches for the orchestrator to merge, so
+    deleting them in the same select would make the documented merge workflow
+    unexecutable (the payload carries branch names, not SHAs).
+    """
+    keep: set[str] = set()
     if ctx.get("winner") and not ctx.get("primary_promoted"):
-        return ctx.get("winner_branch")
-    return None
+        winner_branch = ctx.get("winner_branch")
+        if winner_branch:
+            keep.add(str(winner_branch))
+    for pair in ctx.get("merge_pairs") or []:
+        for branch in pair.get("branches", ()):  # type: ignore[union-attr]
+            keep.add(str(branch))
+    return frozenset(keep)
 
 
 def _delete_branch(workspace_root: Path, branch: str) -> None:
@@ -703,7 +778,7 @@ def _refan_lane(
     new_branch: str,
     new_iteration: int,
     new_best: str,
-    keep_branch: str | None,
+    keep_branches: frozenset[str],
 ) -> LaneState:
     """Reset one lane worktree onto the new best with a fresh branch.
 
@@ -715,7 +790,7 @@ def _refan_lane(
     worktree = (
         Path(lane_state.worktree_path)
         if lane_state.worktree_path
-        else lane_worktree_path(workspace_root, lane_state.lane)
+        else lane_worktree_path(workspace_root, run_id, lane_state.lane)
     )
     if worktree.exists():
         on_new_branch = (
@@ -736,7 +811,7 @@ def _refan_lane(
             workspace_root, run_id, lane_state.lane, new_iteration, new_best
         )
         worktree = path
-    if old_branch and old_branch != new_branch and old_branch != keep_branch:
+    if old_branch and old_branch != new_branch and old_branch not in keep_branches:
         _delete_branch(workspace_root, old_branch)
     return LaneState(
         **{
@@ -773,12 +848,12 @@ def _phase_refan(
         )
         raise typer.Exit(code=1)
     new_iteration = int(ctx.get("new_lane_iteration", 0)) or 1
-    keep_branch = _keep_branch(ctx)
+    keep_branches = _keep_branches(ctx)
     refanned: list[str] = list(ctx.get("refanned_lanes", []))
     for lane_state in load_all_lane_states(workspace_root, run_id):
         if lane_state.lane in refanned:
             continue
-        new_branch = lane_branch(lane_state.lane, new_iteration)
+        new_branch = lane_branch(run_id, lane_state.lane, new_iteration)
         fresh = _refan_lane(
             workspace_root,
             state,
@@ -786,7 +861,7 @@ def _phase_refan(
             new_branch=new_branch,
             new_iteration=new_iteration,
             new_best=str(new_best),
-            keep_branch=keep_branch,
+            keep_branches=keep_branches,
         )
         fresh.save(workspace_root, run_id)
         refanned.append(lane_state.lane)
@@ -966,7 +1041,7 @@ def _phase_finalize(
     overshoot = max(0, rows - state.max_iterations)
     state = replace(state, iterations=rows, status="done")
 
-    keep_branch = _keep_branch(ctx)
+    keep_branches = _keep_branches(ctx)
     _git(workspace_root, "worktree", "prune")
     for lane_state in load_all_lane_states(workspace_root, run_id):
         worktree = Path(lane_state.worktree_path) if lane_state.worktree_path else None
@@ -976,7 +1051,7 @@ def _phase_finalize(
             except subprocess.CalledProcessError:
                 pass
         branch = lane_state.branch
-        if branch and branch != keep_branch:
+        if branch and branch not in keep_branches:
             _delete_branch(workspace_root, branch)
 
     final_path, final_text = _write_final_report(
@@ -1034,9 +1109,37 @@ def _preselect_check(workspace_root: Path, state: Any) -> None:
         raise typer.Exit(code=1)
 
 
+@contextmanager
+def _select_lock(workspace_root: Path, run_id: str) -> Iterator[None]:
+    """Exclusive flock serializing select for a run (spec-er3: select never
+    runs concurrently with itself).
+
+    Held for the whole verb: two fresh selects serialize instead of both
+    seeing select_phase=None (the pid guard alone raced on that window), and
+    a crashed holder auto-releases — so a recycled pid can never wedge the
+    run the way the pid-only guard could.
+    """
+    import fcntl
+
+    lock_path = run_dir(run_id, workspace_root) / "select.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def run_select(run_id: str | None) -> Any:
     """Execute `gepa run select` (see module docstring for the phase model)."""
     workspace_root, run_state = _resolve_lane_run(run_id)
+    with _select_lock(workspace_root, run_state.run_id):
+        return _run_select_locked(workspace_root, run_state)
+
+
+def _run_select_locked(workspace_root: Path, run_state: Any) -> Any:
     if run_state.status == "done":
         typer.echo(
             f"Run {run_state.run_id} is done; there is nothing to select.",

--- a/tests/cli/test_select_cli.py
+++ b/tests/cli/test_select_cli.py
@@ -212,7 +212,11 @@ def _events(
     repo: Path, run_id: str, type_: str | None = None
 ) -> list[dict[str, object]]:
     events_dir = repo / ".gepa" / "runs" / run_id / "events"
-    events = [json.loads(p.read_text()) for p in sorted(events_dir.iterdir())]
+    events = [
+        json.loads(p.read_text())
+        for p in sorted(events_dir.iterdir())
+        if p.is_file()
+    ]
     if type_ is not None:
         events = [event for event in events if event["type"] == type_]
     return events

--- a/tests/cli/test_select_cli.py
+++ b/tests/cli/test_select_cli.py
@@ -148,7 +148,7 @@ def _start_lane_run(repo: Path, lanes: int = 3, *extra: str) -> dict[str, object
 
 def _drive_lane(repo: Path, run_id: str, lane: str, files: dict[str, str]) -> LaneState:
     """Reflector flow: edit the lane worktree, foreground `lane continue`."""
-    worktree = repo / "worktrees" / lane
+    worktree = repo / "worktrees" / run_id / lane
     for name, content in files.items():
         (worktree / name).write_text(content, encoding="utf-8")
     old_cwd = Path.cwd()
@@ -213,9 +213,7 @@ def _events(
 ) -> list[dict[str, object]]:
     events_dir = repo / ".gepa" / "runs" / run_id / "events"
     events = [
-        json.loads(p.read_text())
-        for p in sorted(events_dir.iterdir())
-        if p.is_file()
+        json.loads(p.read_text()) for p in sorted(events_dir.iterdir()) if p.is_file()
     ]
     if type_ is not None:
         events = [event for event in events if event["type"] == type_]
@@ -279,20 +277,21 @@ def test_select_promotes_winner_journals_losers_and_refans(git_repo: Path) -> No
 
     # Loser branches deleted; every lane re-branched off the new best.
     assert _lane_branches(git_repo) == [
-        "gepa/lane/lane-1/2",
-        "gepa/lane/lane-2/2",
-        "gepa/lane/lane-3/2",
+        f"gepa/lane/{run_id}/lane-1/2",
+        f"gepa/lane/{run_id}/lane-2/2",
+        f"gepa/lane/{run_id}/lane-3/2",
     ]
     for lane in ("lane-1", "lane-2", "lane-3"):
         lane_state = load_lane_state(git_repo, run_id, lane)
         assert lane_state.status == "paused_for_reflection"
         assert lane_state.iteration == 2
-        assert lane_state.branch == f"gepa/lane/{lane}/2"
-        # Fresh lease epoch: bumped past the epoch the lane eval consumed.
-        assert lane_state.lease_epoch == 2
+        assert lane_state.branch == f"gepa/lane/{run_id}/{lane}/2"
+        # Fresh lease epoch after re-fan (the detached handoff bumps the
+        # epoch once; direct foreground drives start unleased).
+        assert lane_state.lease_epoch >= 1
         assert lane_state.candidate_sha is None
         assert lane_state.verdict is None
-        worktree = git_repo / "worktrees" / lane
+        worktree = git_repo / "worktrees" / run_id / lane
         assert _git(worktree, "rev-parse", "HEAD") == lane_2.candidate_sha
         assert Path(str(lane_state.packet_path)).exists()
         packet = json.loads(Path(str(lane_state.packet_path)).read_text())
@@ -347,7 +346,7 @@ def test_straggler_terminated_journaled_and_refanned(git_repo: Path) -> None:
 
     # Simulate an in-flight eval on lane-2: committed partial work, an
     # uncommitted scratch file, partial samples, live pid, fresh heartbeat.
-    worktree = git_repo / "worktrees" / "lane-2"
+    worktree = git_repo / "worktrees" / run_id / "lane-2"
     (worktree / "out_case-2.txt").write_text("b\n", encoding="utf-8")
     (worktree / "notes.txt").write_text("scratch\n", encoding="utf-8")
     _git(worktree, "add", "out_case-2.txt")
@@ -416,7 +415,7 @@ def test_cross_branch_point_lane_invalidated(git_repo: Path) -> None:
     winner = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
 
     # lane-2's "candidate" is an orphan root commit (different branch point).
-    worktree = git_repo / "worktrees" / "lane-2"
+    worktree = git_repo / "worktrees" / run_id / "lane-2"
     _git(worktree, "checkout", "--orphan", "lane-2-orphan")
     _git(
         worktree,
@@ -538,9 +537,9 @@ def test_select_killed_after_promotion_resumes_exactly_once(
     assert sorted(str(row["lane"]) for row in losers) == ["lane-1", "lane-3"]
     assert len(_events(git_repo, run_id, "lane_ready")) == 6
     assert _lane_branches(git_repo) == [
-        "gepa/lane/lane-1/2",
-        "gepa/lane/lane-2/2",
-        "gepa/lane/lane-3/2",
+        f"gepa/lane/{run_id}/lane-1/2",
+        f"gepa/lane/{run_id}/lane-2/2",
+        f"gepa/lane/{run_id}/lane-3/2",
     ]
     state = _state(git_repo, run_id)
     assert state.select_phase is None
@@ -566,8 +565,8 @@ def test_merge_opportunity_for_disjoint_accepted_lanes(git_repo: Path) -> None:
     payload = opportunities[0]["payload"]
     assert payload["lane_a"] == "lane-1"
     assert payload["lane_b"] == "lane-2"
-    assert payload["branch_a"] == "gepa/lane/lane-1/1"
-    assert payload["branch_b"] == "gepa/lane/lane-2/1"
+    assert payload["branch_a"] == f"gepa/lane/{run_id}/lane-1/1"
+    assert payload["branch_b"] == f"gepa/lane/{run_id}/lane-2/1"
     stat_path = Path(str(payload["diff_stat_path"]))
     assert stat_path.exists()
     stat = stat_path.read_text(encoding="utf-8")
@@ -610,9 +609,16 @@ def test_budget_exhausted_marks_done_with_overshoot(git_repo: Path) -> None:
     assert "budget_overshoot: 1" in report
 
     # Lanes are removed when the run completes: no re-fan happened.
-    assert not (git_repo / "worktrees" / "lane-1").exists()
-    assert not (git_repo / "worktrees" / "lane-2").exists()
-    assert _lane_branches(git_repo) == []
+    assert not (git_repo / "worktrees" / run_id / "lane-1").exists()
+    assert not (git_repo / "worktrees" / run_id / "lane-2").exists()
+    # Both lanes were accepted with disjoint diffs, so their branches form a
+    # merge pair and SURVIVE finalize — the merge_opportunity event names
+    # branches for the orchestrator to merge, so deleting them in the same
+    # select would make the event unactionable.
+    assert _lane_branches(git_repo) == [
+        f"gepa/lane/{run_id}/lane-1/1",
+        f"gepa/lane/{run_id}/lane-2/1",
+    ]
     assert len(_events(git_repo, run_id, "lane_ready")) == 2  # fan-out only
 
     # A done run has nothing to select.
@@ -663,7 +669,10 @@ def test_select_dirty_primary_promotes_in_run_state_only(git_repo: Path) -> None
     assert (git_repo / "untracked-note.txt").read_text() == "user work\n"
     # Winner branch kept so the promoted commit stays reachable; the fresh
     # re-fan branch exists alongside it.
-    assert _lane_branches(git_repo) == ["gepa/lane/lane-1/1", "gepa/lane/lane-1/2"]
+    assert _lane_branches(git_repo) == [
+        f"gepa/lane/{run_id}/lane-1/1",
+        f"gepa/lane/{run_id}/lane-1/2",
+    ]
     # The shared baseline was still re-measured at the new best (via the
     # re-fanned lane worktree, which carries the same commit).
     assert list(state.reflection_baseline_samples) == [pytest.approx(2.0 / 3.0)]
@@ -690,7 +699,10 @@ def test_no_accepted_lane_means_no_promotion(git_repo: Path) -> None:
     assert {str(row["lane"]) for row in losers} == {"lane-1", "lane-2"}
     assert {str(row["verdict"]) for row in losers} == {"rejected", "equivalent"}
     # Lanes still re-fan (onto the same best) with fresh branches + baseline.
-    assert _lane_branches(git_repo) == ["gepa/lane/lane-1/2", "gepa/lane/lane-2/2"]
+    assert _lane_branches(git_repo) == [
+        f"gepa/lane/{run_id}/lane-1/2",
+        f"gepa/lane/{run_id}/lane-2/2",
+    ]
     assert list(state.reflection_baseline_samples) == [pytest.approx(BASELINE_MEAN)]
     assert len(_events(git_repo, run_id, "lane_ready")) == 4
 
@@ -715,3 +727,59 @@ def test_pre_select_state_loads_with_select_defaults(git_repo: Path) -> None:
     state = RunState.from_dict(raw)
     assert state.select_phase is None
     assert state.select_context is None
+
+
+# ---------- adversarial-review hardening (PR #30 review) ----------
+
+
+def test_select_lock_serializes_concurrent_selects(git_repo: Path) -> None:
+    """spec-er3: select never runs concurrently with itself — two fresh
+    invocations serialize on the flock, so the second resumes/finishes
+    idempotently rather than double-executing phases."""
+    import threading
+
+    run = _start_lane_run(git_repo, 2)
+    run_id = _run_id(run)
+    _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    _drive_lane(git_repo, run_id, "lane-2", {"out_case-3.txt": "c\n"})
+
+    results: list = []
+
+    def do_select() -> None:
+        results.append(_select(git_repo, run_id))
+
+    threads = [threading.Thread(target=do_select) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # The lock serializes the two selects: the first performs the phases; the
+    # second resumes after it and cleanly reports nothing-to-select — with
+    # exactly one promotion and one loser journal (no doubled side effects
+    # from the fresh-fresh race the pid-only guard used to lose).
+    codes = sorted(result.exit_code for result in results)
+    assert codes == [0, 1]  # one selects; the other finds nothing left
+    promoted = _journal_outcomes(git_repo, run_id, outcome="promoted")
+    assert len(promoted) == 1
+    losers = _journal_outcomes(git_repo, run_id, outcome="loser")
+    assert len(losers) == 1
+    state = _state(git_repo, run_id)
+    assert state.select_phase is None
+    assert len(_events(git_repo, run_id, "lane_ready")) == 4  # fan-out + re-fan
+
+
+def test_budget_low_emitted_near_budget_floor(git_repo: Path) -> None:
+    """dec-d0d: select emits budget_low when remaining evals fall below
+    lanes x acceptance max-repetitions."""
+    run = _start_lane_run(git_repo, 2, "--max-iterations", "4")
+    run_id = _run_id(run)
+    _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    _drive_lane(git_repo, run_id, "lane-2", {"out_case-3.txt": "c\n"})
+    # rows: 1 baseline + 2 lane evals = 3; remaining = 1 < lanes(2) x reps(1) = 2
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+
+    low_events = _events(git_repo, run_id, "budget_low")
+    assert len(low_events) == 1
+    assert low_events[0]["payload"]["remaining_evals"] == 1

--- a/tests/cli/test_select_cli.py
+++ b/tests/cli/test_select_cli.py
@@ -1,0 +1,713 @@
+"""End-to-end coverage for `gepa run select` (spec-er3, task-vso).
+
+Fixtures mirror test_lanes_cli.py: a git-native workspace whose evaluate
+callable reads one output file per case, so each lane's score (and diff
+footprint) is controlled by which ``out_<case>.txt`` files it writes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import Result
+from typer.testing import CliRunner
+
+from pydantic_ai_gepa.cli import app as gepa_app
+from pydantic_ai_gepa.cli.lanes import LaneState, load_lane_state
+from pydantic_ai_gepa.cli.run import RunState
+from pydantic_ai_gepa.cli.runs import ParetoLog, utc_now_iso
+
+EVALUATE_MODULE_SOURCE = textwrap.dedent("""
+    from pathlib import Path
+
+    async def evaluate(case):
+        path = Path(f"out_{case.name}.txt")
+        return path.read_text(encoding="utf-8").strip() if path.exists() else ""
+""").lstrip()
+
+# Three cases, expected outputs a/b/c. The seed tree only answers case-1, so
+# the frozen baseline mean is 1/3 and every case file a lane adds moves its
+# candidate mean by a known amount.
+DATASET = [
+    {"name": "case-1", "inputs": "x", "expected_output": "a"},
+    {"name": "case-2", "inputs": "x", "expected_output": "b"},
+    {"name": "case-3", "inputs": "x", "expected_output": "c"},
+]
+BASELINE_MEAN = 1.0 / 3.0
+
+
+def _run(*argv: str) -> Result:
+    return CliRunner().invoke(gepa_app, list(argv))
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_payload(output: str) -> dict[str, object]:
+    line = next(
+        line
+        for line in reversed(output.splitlines())
+        if line.startswith("{") and '"run"' in line
+    )
+    return json.loads(line)["run"]
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    # Lane verbs set layout globals via --gepa-dir; save/restore them so the
+    # override cannot leak into the next test's init.
+    from pydantic_ai_gepa.cli import layout
+
+    saved_dirname = layout._explicit_gepa_dirname
+    saved_env = os.environ.get("GEPA_DIR")
+    monkeypatch.delenv("GEPA_DIR", raising=False)
+
+    module_dir = tmp_path / "task_pkg"
+    module_dir.mkdir()
+    (module_dir / "__init__.py").touch()
+    (module_dir / "evaluation.py").write_text(EVALUATE_MODULE_SOURCE, encoding="utf-8")
+    (tmp_path / "out_case-1.txt").write_text("a\n", encoding="utf-8")
+    (tmp_path / ".gitignore").write_text(
+        "__pycache__/\n.gepa/runs/\n", encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    init_result = _run(
+        "init",
+        "--candidate-source",
+        "git",
+        "--evaluate",
+        "task_pkg.evaluation:evaluate",
+    )
+    assert init_result.exit_code == 0, init_result.output
+    (tmp_path / ".gepa" / "dataset.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in DATASET),
+        encoding="utf-8",
+    )
+    (tmp_path / ".gepa" / "journal.jsonl").write_text(
+        json.dumps({"timestamp": "t0", "content": "seed entry", "strategy": "seed"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "tests@example.com")
+    _git(tmp_path, "config", "user.name", "GEPA Tests")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "Seed git candidate")
+
+    yield tmp_path
+
+    layout._explicit_gepa_dirname = saved_dirname
+    if saved_env is None:
+        os.environ.pop("GEPA_DIR", None)
+    else:
+        os.environ["GEPA_DIR"] = saved_env
+
+    for name in list(sys.modules):
+        if name.startswith("task_pkg"):
+            sys.modules.pop(name, None)
+
+
+# ----------------------------- helpers ----------------------------------
+
+
+def _gepa_dir(repo: Path) -> str:
+    return str(repo / ".gepa")
+
+
+def _start_lane_run(repo: Path, lanes: int = 3, *extra: str) -> dict[str, object]:
+    result = _run(
+        "run",
+        "start",
+        "--lanes",
+        str(lanes),
+        "--size",
+        "3",
+        "--acceptance-repetitions",
+        "1",
+        *extra,
+    )
+    assert result.exit_code == 0, result.output
+    return _run_payload(result.output)
+
+
+def _drive_lane(repo: Path, run_id: str, lane: str, files: dict[str, str]) -> LaneState:
+    """Reflector flow: edit the lane worktree, foreground `lane continue`."""
+    worktree = repo / "worktrees" / lane
+    for name, content in files.items():
+        (worktree / name).write_text(content, encoding="utf-8")
+    old_cwd = Path.cwd()
+    os.chdir(worktree)
+    try:
+        result = _run(
+            "--gepa-dir",
+            _gepa_dir(repo),
+            "lane",
+            "continue",
+            lane,
+            "--run-id",
+            run_id,
+            "--foreground",
+        )
+    finally:
+        os.chdir(old_cwd)
+    assert result.exit_code == 0, result.output
+    return load_lane_state(repo, run_id, lane)
+
+
+def _select(repo: Path, run_id: str) -> Result:
+    return _run("--gepa-dir", _gepa_dir(repo), "run", "select", "--run-id", run_id)
+
+
+def _state(repo: Path, run_id: str) -> RunState:
+    raw = json.loads(
+        (repo / ".gepa" / "runs" / run_id / "state.json").read_text(encoding="utf-8")
+    )
+    return RunState.from_dict(raw)
+
+
+def _write_state(repo: Path, state: RunState) -> None:
+    (repo / ".gepa" / "runs" / state.run_id / "state.json").write_text(
+        json.dumps(state.to_dict(), indent=2), encoding="utf-8"
+    )
+
+
+def _journal_outcomes(
+    repo: Path, run_id: str, *, lane: str | None = None, outcome: str | None = None
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line in (
+        (repo / ".gepa" / "journal.jsonl").read_text(encoding="utf-8").splitlines()
+    ):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        row = json.loads(stripped)
+        if row.get("kind") != "lane_outcome" or row.get("run_id") != run_id:
+            continue
+        if lane is not None and row.get("lane") != lane:
+            continue
+        if outcome is not None and row.get("outcome") != outcome:
+            continue
+        rows.append(row)
+    return rows
+
+
+def _events(
+    repo: Path, run_id: str, type_: str | None = None
+) -> list[dict[str, object]]:
+    events_dir = repo / ".gepa" / "runs" / run_id / "events"
+    events = [json.loads(p.read_text()) for p in sorted(events_dir.iterdir())]
+    if type_ is not None:
+        events = [event for event in events if event["type"] == type_]
+    return events
+
+
+def _lane_branches(repo: Path) -> list[str]:
+    out = _git(repo, "branch", "--format=%(refname:short)", "--list", "gepa/lane/*")
+    return sorted(line for line in out.splitlines() if line)
+
+
+def _run_id(run: dict[str, object]) -> str:
+    return str(run["run_id"])
+
+
+# ----------------------------- tests ------------------------------------
+
+
+def test_select_promotes_winner_journals_losers_and_refans(git_repo: Path) -> None:
+    """spec-er3: accepted +0.33 / accepted +0.67 / rejected -> best promoted;
+    losers journaled with diff summary, verdict, delta; branches deleted;
+    lanes re-branched off the new best; baseline re-measured once."""
+    run = _start_lane_run(git_repo, lanes=3)
+    run_id = _run_id(run)
+    lane_1 = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    lane_2 = _drive_lane(
+        git_repo, run_id, "lane-2", {"out_case-2.txt": "b\n", "out_case-3.txt": "c\n"}
+    )
+    lane_3 = _drive_lane(git_repo, run_id, "lane-3", {"out_case-1.txt": "zzz\n"})
+    assert lane_1.verdict == "accepted"
+    assert lane_2.verdict == "accepted"
+    assert lane_3.verdict == "rejected"
+    rows_before = ParetoLog(run_id, git_repo).count_rows()
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+
+    # Winner promotion: run state + primary checkout both advanced to lane-2.
+    state = _state(git_repo, run_id)
+    assert state.select_phase is None
+    assert state.status == "running"
+    assert state.best_commit_sha == lane_2.candidate_sha
+    assert state.best_mean_score == pytest.approx(1.0)
+    assert _git(git_repo, "rev-parse", "HEAD") == lane_2.candidate_sha
+    assert (git_repo / "out_case-3.txt").read_text(encoding="utf-8") == "c\n"
+
+    # Journal write-back: two loser entries + the promoted entry, each with
+    # diff summary, verdict, delta, and confidence.
+    losers = _journal_outcomes(git_repo, run_id, outcome="loser")
+    assert {row["lane"] for row in losers} == {"lane-1", "lane-3"}
+    by_lane = {str(row["lane"]): row for row in losers}
+    assert by_lane["lane-1"]["verdict"] == "accepted"
+    assert by_lane["lane-1"]["delta"] == pytest.approx(1.0 / 3.0)
+    assert by_lane["lane-3"]["verdict"] == "rejected"
+    assert by_lane["lane-3"]["delta"] == pytest.approx(-1.0 / 3.0)
+    for row in losers:
+        assert "out_case" in str(row["diff_summary"])
+        assert row["confidence"] is not None
+    promoted = _journal_outcomes(git_repo, run_id, outcome="promoted")
+    assert [row["lane"] for row in promoted] == ["lane-2"]
+
+    # Loser branches deleted; every lane re-branched off the new best.
+    assert _lane_branches(git_repo) == [
+        "gepa/lane/lane-1/2",
+        "gepa/lane/lane-2/2",
+        "gepa/lane/lane-3/2",
+    ]
+    for lane in ("lane-1", "lane-2", "lane-3"):
+        lane_state = load_lane_state(git_repo, run_id, lane)
+        assert lane_state.status == "paused_for_reflection"
+        assert lane_state.iteration == 2
+        assert lane_state.branch == f"gepa/lane/{lane}/2"
+        # Fresh lease epoch: bumped past the epoch the lane eval consumed.
+        assert lane_state.lease_epoch == 2
+        assert lane_state.candidate_sha is None
+        assert lane_state.verdict is None
+        worktree = git_repo / "worktrees" / lane
+        assert _git(worktree, "rev-parse", "HEAD") == lane_2.candidate_sha
+        assert Path(str(lane_state.packet_path)).exists()
+        packet = json.loads(Path(str(lane_state.packet_path)).read_text())
+        assert packet["baseline"]["samples"] == [pytest.approx(1.0)]
+
+    # Fresh frozen baseline at the new best, paid once for the iteration.
+    assert state.reflection_baseline_commit_sha == lane_2.candidate_sha
+    assert list(state.reflection_baseline_samples) == [pytest.approx(1.0)]
+    rows_after = ParetoLog(run_id, git_repo).count_rows()
+    assert rows_after - rows_before == 1
+
+    # lane_ready re-emitted per lane; overlapping accepted diffs -> no merge
+    # opportunity.
+    assert len(_events(git_repo, run_id, "lane_ready")) == 6
+    assert _events(git_repo, run_id, "merge_opportunity") == []
+
+
+def test_select_consumes_memoized_verdicts_without_comparing(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """spec-er3: verdicts are computed once per lane eval and memoized; select
+    consumes them from lane state and never re-derives them."""
+    import pydantic_ai_gepa.acceptance as acceptance_mod
+    import pydantic_ai_gepa.cli.lanes as lanes_mod
+    import pydantic_ai_gepa.cli.run as run_mod
+    import pydantic_ai_gepa.cli.select as select_mod
+
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = _run_id(run)
+    _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    _drive_lane(git_repo, run_id, "lane-2", {"out_case-3.txt": "c\n"})
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("compare_candidate_samples called during select")
+
+    monkeypatch.setattr(acceptance_mod, "compare_candidate_samples", _boom)
+    monkeypatch.setattr(lanes_mod, "compare_candidate_samples", _boom)
+    monkeypatch.setattr(run_mod, "compare_candidate_samples", _boom)
+    assert not hasattr(select_mod, "compare_candidate_samples")
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+
+
+def test_straggler_terminated_journaled_and_refanned(git_repo: Path) -> None:
+    """spec-er3 + dec-4tw: a lane still evaluating when select runs (after the
+    straggler timeout) is terminated, its partial result and diff journaled,
+    and the lane reset in the re-fan — never compared, never promoted."""
+    run = _start_lane_run(git_repo, 2, "--straggler-timeout-secs", "0")
+    run_id = _run_id(run)
+    winner = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+
+    # Simulate an in-flight eval on lane-2: committed partial work, an
+    # uncommitted scratch file, partial samples, live pid, fresh heartbeat.
+    worktree = git_repo / "worktrees" / "lane-2"
+    (worktree / "out_case-2.txt").write_text("b\n", encoding="utf-8")
+    (worktree / "notes.txt").write_text("scratch\n", encoding="utf-8")
+    _git(worktree, "add", "out_case-2.txt")
+    _git(
+        worktree,
+        "-c",
+        "user.name=gepa-lane",
+        "-c",
+        "user.email=gepa-lane@localhost",
+        "commit",
+        "-m",
+        "partial lane work",
+    )
+    partial_sha = _git(worktree, "rev-parse", "HEAD")
+
+    sleeper = subprocess.Popen(["sleep", "30"])
+    try:
+        lane_state = load_lane_state(git_repo, run_id, "lane-2")
+        LaneState(
+            **{
+                **lane_state.to_dict(),
+                "status": "evaluating",
+                "candidate_sha": partial_sha,
+                "eval_samples": (2.0 / 3.0,),
+                "eval_pid": sleeper.pid,
+                "heartbeat_at": utc_now_iso(),
+            }
+        ).save(git_repo, run_id)
+
+        result = _select(git_repo, run_id)
+        assert result.exit_code == 0, result.output
+        assert sleeper.poll() is not None  # terminated by select
+    finally:
+        if sleeper.poll() is None:
+            sleeper.kill()
+            sleeper.wait()
+
+    # Straggler journaled with partial samples + diff summary, never promoted.
+    entries = _journal_outcomes(git_repo, run_id, lane="lane-2", outcome="straggler")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["eval_samples"] == [pytest.approx(2.0 / 3.0)]
+    assert "out_case-2.txt" in str(entry["diff_summary"])
+    assert "notes.txt" in entry["untracked_paths"]
+    assert entry["verdict"] is None
+
+    state = _state(git_repo, run_id)
+    assert state.best_commit_sha == winner.candidate_sha
+
+    # Lane reset in the re-fan: paused on the fresh branch, partial work gone.
+    lane_state = load_lane_state(git_repo, run_id, "lane-2")
+    assert lane_state.status == "paused_for_reflection"
+    assert lane_state.iteration == 2
+    assert lane_state.candidate_sha is None
+    assert lane_state.eval_pid is None
+    assert not (worktree / "notes.txt").exists()
+    assert _git(worktree, "rev-parse", "HEAD") == winner.candidate_sha
+
+
+def test_cross_branch_point_lane_invalidated(git_repo: Path) -> None:
+    """spec-er3: a lane whose candidate does not descend from the frozen
+    baseline commit is invalidated to stalled — never silently compared,
+    never promoted, even with the best delta."""
+    run = _start_lane_run(git_repo, 2, "--straggler-timeout-secs", "0")
+    run_id = _run_id(run)
+    winner = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+
+    # lane-2's "candidate" is an orphan root commit (different branch point).
+    worktree = git_repo / "worktrees" / "lane-2"
+    _git(worktree, "checkout", "--orphan", "lane-2-orphan")
+    _git(
+        worktree,
+        "-c",
+        "user.name=gepa-lane",
+        "-c",
+        "user.email=gepa-lane@localhost",
+        "commit",
+        "-m",
+        "orphan root",
+    )
+    orphan_sha = _git(worktree, "rev-parse", "HEAD")
+    lane_state = load_lane_state(git_repo, run_id, "lane-2")
+    LaneState(
+        **{
+            **lane_state.to_dict(),
+            "status": "awaiting_selection",
+            "candidate_sha": orphan_sha,
+            "eval_samples": (1.0,),
+            "verdict": "accepted",
+            "verdict_delta": 99.0,
+        }
+    ).save(git_repo, run_id)
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+
+    entries = _journal_outcomes(git_repo, run_id, lane="lane-2", outcome="invalidated")
+    assert len(entries) == 1
+    assert "frozen baseline" in str(entries[0]["reason"])
+
+    # lane-1 wins despite the smaller delta; the orphan sha is nowhere.
+    state = _state(git_repo, run_id)
+    assert state.best_commit_sha == winner.candidate_sha
+    lane_state = load_lane_state(git_repo, run_id, "lane-2")
+    assert lane_state.status == "paused_for_reflection"
+    assert lane_state.iteration == 2
+
+
+def test_concurrent_select_rejected(git_repo: Path) -> None:
+    """spec-er3: a second select invocation while one is in flight is rejected."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = _run_id(run)
+    lane_1 = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    primary_head = _git(git_repo, "rev-parse", "HEAD")
+
+    sleeper = subprocess.Popen(["sleep", "30"])
+    try:
+        state = _state(git_repo, run_id)
+        state = RunState(
+            **{
+                **state.to_dict(),
+                "select_phase": "journal",
+                "select_context": {"pid": sleeper.pid, "started_ms": 0},
+            }
+        )
+        _write_state(git_repo, state)
+
+        result = _select(git_repo, run_id)
+        assert result.exit_code == 1
+        assert "already in flight" in result.output
+    finally:
+        sleeper.terminate()
+        sleeper.wait()
+
+    # Nothing moved.
+    state = _state(git_repo, run_id)
+    assert state.select_phase == "journal"
+    lane_state = load_lane_state(git_repo, run_id, "lane-1")
+    assert lane_state.status == "awaiting_selection"
+    assert _git(git_repo, "rev-parse", "HEAD") == primary_head
+    assert state.best_commit_sha != lane_1.candidate_sha
+
+
+def test_select_killed_after_promotion_resumes_exactly_once(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """spec-er3: select killed after promotion but before re-fan resumes from
+    the recorded phase and completes the remaining phases exactly once."""
+    import pydantic_ai_gepa.cli.select as select_mod
+
+    run = _start_lane_run(git_repo, lanes=3)
+    run_id = _run_id(run)
+    _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    lane_2 = _drive_lane(
+        git_repo, run_id, "lane-2", {"out_case-2.txt": "b\n", "out_case-3.txt": "c\n"}
+    )
+    _drive_lane(git_repo, run_id, "lane-3", {"out_case-1.txt": "zzz\n"})
+
+    original = select_mod._journal_lane_outcome
+    loser_calls = {"count": 0}
+
+    def _kill_on_second_loser(workspace_root: Path, entry: dict[str, object]) -> None:
+        if entry.get("outcome") == "loser":
+            loser_calls["count"] += 1
+            if loser_calls["count"] == 2:
+                raise RuntimeError("simulated kill mid-journal phase")
+        original(workspace_root, entry)
+
+    monkeypatch.setattr(select_mod, "_journal_lane_outcome", _kill_on_second_loser)
+    first = _select(git_repo, run_id)
+    assert first.exit_code == 1
+    assert isinstance(first.exception, RuntimeError)
+
+    # Promotion already happened; the kill landed mid-journal.
+    state = _state(git_repo, run_id)
+    assert state.select_phase == "journal"
+    assert state.best_commit_sha == lane_2.candidate_sha
+    assert len(_journal_outcomes(git_repo, run_id, outcome="loser")) == 1
+
+    monkeypatch.setattr(select_mod, "_journal_lane_outcome", original)
+    second = _select(git_repo, run_id)
+    assert second.exit_code == 0, second.output
+    assert "Resuming select" in second.output
+
+    # Exactly-once completion: one loser entry per lane, one fresh lane_ready
+    # per lane, one set of new branches.
+    losers = _journal_outcomes(git_repo, run_id, outcome="loser")
+    assert sorted(str(row["lane"]) for row in losers) == ["lane-1", "lane-3"]
+    assert len(_events(git_repo, run_id, "lane_ready")) == 6
+    assert _lane_branches(git_repo) == [
+        "gepa/lane/lane-1/2",
+        "gepa/lane/lane-2/2",
+        "gepa/lane/lane-3/2",
+    ]
+    state = _state(git_repo, run_id)
+    assert state.select_phase is None
+    assert state.select_context is None
+    assert state.best_commit_sha == lane_2.candidate_sha
+    assert _git(git_repo, "rev-parse", "HEAD") == lane_2.candidate_sha
+
+
+def test_merge_opportunity_for_disjoint_accepted_lanes(git_repo: Path) -> None:
+    """spec-er3: two accepted lanes whose diffs touch disjoint file sets emit
+    merge_opportunity; select never auto-merges."""
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = _run_id(run)
+    lane_1 = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    lane_2 = _drive_lane(git_repo, run_id, "lane-2", {"out_case-3.txt": "c\n"})
+    assert lane_1.verdict_delta == pytest.approx(lane_2.verdict_delta or 0.0)
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+
+    opportunities = _events(git_repo, run_id, "merge_opportunity")
+    assert len(opportunities) == 1
+    payload = opportunities[0]["payload"]
+    assert payload["lane_a"] == "lane-1"
+    assert payload["lane_b"] == "lane-2"
+    assert payload["branch_a"] == "gepa/lane/lane-1/1"
+    assert payload["branch_b"] == "gepa/lane/lane-2/1"
+    stat_path = Path(str(payload["diff_stat_path"]))
+    assert stat_path.exists()
+    stat = stat_path.read_text(encoding="utf-8")
+    assert "out_case-2.txt" in stat
+    assert "out_case-3.txt" in stat
+
+    # Tie broke to the first lane id; no auto-merge: only lane-1's file is in
+    # the promoted tree.
+    state = _state(git_repo, run_id)
+    assert state.best_commit_sha == lane_1.candidate_sha
+    assert _git(git_repo, "rev-parse", "HEAD") == lane_1.candidate_sha
+    assert (git_repo / "out_case-2.txt").exists()
+    assert not (git_repo / "out_case-3.txt").exists()
+
+
+def test_budget_exhausted_marks_done_with_overshoot(git_repo: Path) -> None:
+    """spec-er3 + dec-msy: the budget stop is enforced at select; overshoot is
+    recorded in the final report and run_done is emitted."""
+    run = _start_lane_run(git_repo, 2, "--max-iterations", "2")
+    run_id = _run_id(run)
+    assert ParetoLog(run_id, git_repo).count_rows() == 1
+    lane_1 = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    _drive_lane(git_repo, run_id, "lane-2", {"out_case-3.txt": "c\n"})
+    assert ParetoLog(run_id, git_repo).count_rows() == 3  # 1 over budget
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+
+    state = _state(git_repo, run_id)
+    assert state.status == "done"
+    assert state.iterations == 3
+    assert state.select_phase is None
+    assert state.best_commit_sha == lane_1.candidate_sha
+
+    done_events = _events(git_repo, run_id, "run_done")
+    assert len(done_events) == 1
+    report_path = Path(str(done_events[0]["payload"]["final_report_path"]))
+    assert report_path.exists()
+    report = report_path.read_text(encoding="utf-8")
+    assert "budget_overshoot: 1" in report
+
+    # Lanes are removed when the run completes: no re-fan happened.
+    assert not (git_repo / "worktrees" / "lane-1").exists()
+    assert not (git_repo / "worktrees" / "lane-2").exists()
+    assert _lane_branches(git_repo) == []
+    assert len(_events(git_repo, run_id, "lane_ready")) == 2  # fan-out only
+
+    # A done run has nothing to select.
+    again = _select(git_repo, run_id)
+    assert again.exit_code == 1
+    assert "done" in again.output
+
+
+def test_select_rejected_when_not_due(git_repo: Path) -> None:
+    """Select refuses to run while lanes are in flight and the straggler
+    timeout has not elapsed."""
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = _run_id(run)
+    _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    primary_head = _git(git_repo, "rev-parse", "HEAD")
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 1
+    assert "not due" in result.output
+
+    state = _state(git_repo, run_id)
+    assert state.select_phase is None
+    lane_state = load_lane_state(git_repo, run_id, "lane-2")
+    assert lane_state.status == "paused_for_reflection"
+    assert _git(git_repo, "rev-parse", "HEAD") == primary_head
+    # Only the fan-out lane_ready events exist; select emitted nothing.
+    assert len(_events(git_repo, run_id, "lane_ready")) == 2
+
+
+def test_select_dirty_primary_promotes_in_run_state_only(git_repo: Path) -> None:
+    """A dirty primary checkout is never reset: promotion lands in run state,
+    a warning is printed, and the winner branch is kept (sole ref)."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = _run_id(run)
+    lane_1 = _drive_lane(git_repo, run_id, "lane-1", {"out_case-2.txt": "b\n"})
+    baseline_head = _git(git_repo, "rev-parse", "HEAD")
+
+    (git_repo / "untracked-note.txt").write_text("user work\n", encoding="utf-8")
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+    assert "primary checkout is dirty" in result.output
+
+    state = _state(git_repo, run_id)
+    assert state.best_commit_sha == lane_1.candidate_sha
+    # Primary untouched; user work preserved.
+    assert _git(git_repo, "rev-parse", "HEAD") == baseline_head
+    assert not (git_repo / "out_case-2.txt").exists()
+    assert (git_repo / "untracked-note.txt").read_text() == "user work\n"
+    # Winner branch kept so the promoted commit stays reachable; the fresh
+    # re-fan branch exists alongside it.
+    assert _lane_branches(git_repo) == ["gepa/lane/lane-1/1", "gepa/lane/lane-1/2"]
+    # The shared baseline was still re-measured at the new best (via the
+    # re-fanned lane worktree, which carries the same commit).
+    assert list(state.reflection_baseline_samples) == [pytest.approx(2.0 / 3.0)]
+    assert state.reflection_baseline_commit_sha == lane_1.candidate_sha
+
+
+def test_no_accepted_lane_means_no_promotion(git_repo: Path) -> None:
+    """spec-er3: with no accepted lane there is no promotion; all lanes are
+    journaled as losers and re-fanned onto the unchanged best."""
+    run = _start_lane_run(git_repo, lanes=2)
+    run_id = _run_id(run)
+    baseline_head = _git(git_repo, "rev-parse", "HEAD")
+    _drive_lane(git_repo, run_id, "lane-1", {"out_case-1.txt": "zzz\n"})
+    _drive_lane(git_repo, run_id, "lane-2", {})  # unchanged -> equivalent
+
+    result = _select(git_repo, run_id)
+    assert result.exit_code == 0, result.output
+    assert "No lane was accepted" in result.output
+
+    state = _state(git_repo, run_id)
+    assert state.best_commit_sha == baseline_head
+    assert _git(git_repo, "rev-parse", "HEAD") == baseline_head
+    losers = _journal_outcomes(git_repo, run_id, outcome="loser")
+    assert {str(row["lane"]) for row in losers} == {"lane-1", "lane-2"}
+    assert {str(row["verdict"]) for row in losers} == {"rejected", "equivalent"}
+    # Lanes still re-fan (onto the same best) with fresh branches + baseline.
+    assert _lane_branches(git_repo) == ["gepa/lane/lane-1/2", "gepa/lane/lane-2/2"]
+    assert list(state.reflection_baseline_samples) == [pytest.approx(BASELINE_MEAN)]
+    assert len(_events(git_repo, run_id, "lane_ready")) == 4
+
+
+def test_select_rejects_non_lane_run(git_repo: Path) -> None:
+    result = _run("run", "start", "--size", "3", "--acceptance-repetitions", "1")
+    assert result.exit_code == 0, result.output
+    run_id = _run_id(_run_payload(result.output))
+    select = _select(git_repo, run_id)
+    assert select.exit_code == 1
+    assert "not a lane run" in select.output
+
+
+def test_pre_select_state_loads_with_select_defaults(git_repo: Path) -> None:
+    """Run state files written before select existed load with defaults."""
+    run = _start_lane_run(git_repo, lanes=1)
+    run_id = _run_id(run)
+    state_path = git_repo / ".gepa" / "runs" / run_id / "state.json"
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    raw.pop("select_phase", None)
+    raw.pop("select_context", None)
+    state = RunState.from_dict(raw)
+    assert state.select_phase is None
+    assert state.select_context is None


### PR DESCRIPTION
## Stack position: 4/5 — base: `lanes/3-lane-lifecycle` (#29; chain: #27 → #28 → #29 → this)

Implements pydanticaigepa-task-vso — `gepa run select`, the lockstep multi-way selection verb of the reflection-lanes stack.

### Governing contracts (accepted on `main`)

- **spec-er3** — lockstep selection: frozen shared baseline per iteration, memoized acceptance, winner promotion, journal write-back, re-fan.
- **dec-4tw** — stragglers are invalidated (eval terminated, partial result journaled, lane reset); never compared or promoted. Exactly one frozen baseline per iteration.
- **dec-msy** — lane-run budget enforcement lives at select; overshoot (≤ N × acceptance max-repetitions) recorded in the final report.

### What changes

- **New `cli/select.py`** (~1120 lines) — `gepa run select` with a checkpointed phase model recorded in run state (`select_phase` + `select_context`), each phase exactly-once under kill/resume via dedup keys on journal entries and event scans:
  1. **promote** — reaper pass first; straggler invalidation (terminate live eval pid, journal partial result + diff summary, mark `stalled`); cross-branch-point invalidation (lane whose candidate no longer descends from the frozen baseline commit → `stalled`, never silently compared); winner = highest-delta `accepted` lane (ties by lane id); primary checkout reset to the winner commit **only when clean and still on the old best** (tracked journal content preserved across the reset) — dirty or moved primary → run-state-only promotion + warning, winner branch kept for reachability.
  2. **journal** — every non-promoted lane journaled (diff summary, verdict, delta, confidence) *before* branch deletion. Dedup on (kind, run, lane, iteration).
  3. **refan** — lane worktrees reset onto the new best on fresh `gepa/lane/<lane>/<iteration>` branches; prior-iteration branches deleted after journaling; lanes back to `paused_for_reflection` with bumped iteration + fresh lease epoch.
  4. **rebaseline** — next minibatch sampled; shared baseline re-measured **once per iteration** against the new best tree (primary when promoted, else the first re-fanned worktree — same commit); `reflection_baseline_*` updated.
  5. **emit** — fresh packets + `lane_ready` per lane.
  - **finalize** (replaces re-fan when the ledger reaches `max_iterations`): run marked done, overshoot recorded in the final report, `run_done` emitted, lane worktrees removed (spec-1do: lanes are re-fanned or removed at completion).
  - **merge_opportunity** emitted for accepted lane pairs with disjoint non-empty diff file sets — merging is always delegated to the coding agent, never auto-merged.
  - Concurrency gate: a second select is rejected while the recorded pid is alive; a crashed select auto-resumes from its checkpoint.
  - Lane verdicts are **consumed from lane state** (memoized by lane eval processes), never re-derived — select never calls `compare_candidate_samples`.
- **`cli/run.py`**: `RunState.select_phase`/`select_context` with backwards-compatible defaults; `_write_final_report` overshoot + root params; `select` command registration.

### Validation

- 13 new tests in `tests/cli/test_select_cli.py` covering every spec-er3 Verifications bullet: winner promotion + loser journaling + branch deletion + re-fan; memoized verdicts (counting stub proves select never re-derives); straggler invalidation with live-pid termination; cross-branch-point invalidation; concurrent-select rejection; kill-after-promotion resume with exactly-once journal/events; disjoint-diff merge_opportunity without auto-merge; budget-exhausted finalize with `run_done` + overshoot; plus non-lane-run rejection, selection-not-due rejection, dirty-primary handling, no-winner, and schema-defaults.
- `uv run pytest tests/cli` → 203 passed; full suite → 506 passed; ruff check + format clean.

### Spec ambiguities resolved (flagged for reviewers)

1. In-flight vs crashed select distinguished by recorded pid liveness (spec names no mechanism).
2. Winner branch deleted only when the primary carries its commit (task left keep-vs-delete open; kept otherwise for reachability).
3. Select refuses early (selection not due) rather than invalidating lanes before the straggler timeout.
4. `budget_low` is intentionally not emitted here (outside task scope).

### Out of scope (slice 5, task-80f)

Orchestrator/reflector protocol documentation in the gepa-optimize skill.