### PR TITLE
Add objective-aware engine accounting

### DIFF
--- a/src/pydantic_ai_gepa/adapters/agent_adapter.py
+++ b/src/pydantic_ai_gepa/adapters/agent_adapter.py
@@ -866,6 +866,11 @@ class _BaseAgentAdapter(
                 "score": metric_result.score,
                 "feedback": metric_result.feedback,
             }
+            if metric_result.side_info is not None:
+                # Keep objective/selectability material available even when a
+                # caller intentionally disables trace capture, without
+                # changing the historic reflection side-info aggregate.
+                result["metric_side_info"] = metric_result.side_info
             if trajectory is not None:
                 result["trajectory"] = trajectory
             return result

--- a/src/pydantic_ai_gepa/cli/eval.py
+++ b/src/pydantic_ai_gepa/cli/eval.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -95,6 +96,61 @@ def _count_evals_in_run(run_id: str, root: Path | None = None) -> int:
 
 
 DEFAULT_FAILURE_THRESHOLD = 0.999
+
+
+def _objective_scores(
+    records: list[EvaluationRecord],
+) -> tuple[dict[str, float], dict[str, dict[str, float]], bool]:
+    """Extract validated higher-is-better objective coordinates from metric ASI."""
+    values: dict[str, list[float]] = {}
+    per_case: dict[str, dict[str, float]] = {}
+    selectable = True
+    objective_key_sets: list[set[str] | None] = []
+    for record in records:
+        info = record.payload.get("side_info")
+        if not isinstance(info, dict):
+            info = record.payload.get("metric_side_info")
+        if not isinstance(info, dict):
+            info = getattr(record.payload.get("trajectory"), "metric_side_info", None)
+        if not isinstance(info, dict):
+            objective_key_sets.append(None)
+            continue
+        if info.get("selectable") is False or info.get("infrastructure_valid") is False:
+            selectable = False
+        raw = info.get("scores")
+        if raw is None:
+            objective_key_sets.append(None)
+            continue
+        if not isinstance(raw, dict):
+            raise typer.BadParameter("Metric side_info['scores'] must be a mapping.")
+        case_values: dict[str, float] = {}
+        objective_key_sets.append({str(name) for name in raw})
+        for name, value in raw.items():
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+            ):
+                raise typer.BadParameter(
+                    f"Objective score {name!r} for {record.case_id!r} must be finite numeric."
+                )
+            key = str(name)
+            number = float(value)
+            values.setdefault(key, []).append(number)
+            case_values[key] = number
+        if case_values:
+            per_case[record.case_id] = case_values
+    if any(keys is not None for keys in objective_key_sets):
+        first = objective_key_sets[0]
+        if first is None or any(keys != first for keys in objective_key_sets[1:]):
+            raise typer.BadParameter(
+                "Metric side_info['scores'] must expose identical objective keys for every evaluated case."
+            )
+    return (
+        {key: sum(items) / len(items) for key, items in values.items()},
+        per_case,
+        selectable,
+    )
 
 
 @dataclass(frozen=True)
@@ -488,10 +544,13 @@ def run_eval_once(
     per_case = {record.case_id: record.score for record in records}
     mean = sum(per_case.values()) / len(per_case) if per_case else 0.0
     infrastructure_failures = evaluation_infrastructure_failures(records)
+    objective_scores, per_case_objective_scores, metric_selectable = _objective_scores(
+        records
+    )
     evaluation_outcome = (
         "infrastructure_failure" if infrastructure_failures else "valid"
     )
-    selectable = not infrastructure_failures
+    selectable = not infrastructure_failures and metric_selectable
     pareto_status = "infrastructure_failure" if infrastructure_failures else status
 
     pareto = ParetoLog(active_run_id, workspace_root)
@@ -511,6 +570,8 @@ def run_eval_once(
             summary=f"{pareto_status} eval of {candidate.id} on minibatch {minibatch.id} (mean={mean:.3f})",
             timestamp=utc_now_iso(),
             lane=lane,
+            objective_scores=objective_scores,
+            per_case_objective_scores=per_case_objective_scores,
             extra={
                 "eval_id": eval_id,
                 "outcome": evaluation_outcome,
@@ -560,6 +621,8 @@ def run_eval_once(
         "selectable": selectable,
         "evaluation_errors": [failure.to_dict() for failure in infrastructure_failures],
         "mean_score": mean,
+        "objective_scores": objective_scores,
+        "per_case_objective_scores": per_case_objective_scores,
         "n_cases": len(records),
         "n_failures": len([record for record in records if record.score < threshold]),
         "iterations": iteration,

--- a/src/pydantic_ai_gepa/cli/pareto.py
+++ b/src/pydantic_ai_gepa/cli/pareto.py
@@ -61,6 +61,11 @@ def pareto(
         "--front/--all",
         help="--all (default) shows full chronological history; --front shows only Pareto-dominant rows (useful with multi-objective scoring; mostly degenerate with a single-objective mean).",
     ),
+    frontier: str = typer.Option(
+        "instance",
+        "--frontier",
+        help="Frontier coordinates: instance | objective | hybrid | cartesian.",
+    ),
 ) -> None:
     """Show the eval history for a run (default) or just the Pareto front (`--front`)."""
     try:
@@ -73,7 +78,11 @@ def pareto(
         raise
 
     log = ParetoLog(active_run)
-    rows = log.front() if front else log.iter_rows()
+    try:
+        rows = log.front(mode=frontier) if front else log.iter_rows()
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
 
     if format_ == "json":
         typer.echo(json.dumps(_rows_for_output(rows), indent=2))

--- a/src/pydantic_ai_gepa/cli/runs.py
+++ b/src/pydantic_ai_gepa/cli/runs.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import random
 import subprocess
@@ -187,6 +188,8 @@ class ParetoRow:
     summary: str
     timestamp: str
     lane: str | None = None
+    objective_scores: dict[str, float] = field(default_factory=dict)
+    per_case_objective_scores: dict[str, dict[str, float]] = field(default_factory=dict)
     extra: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -201,6 +204,11 @@ class ParetoRow:
             "summary": self.summary,
             "timestamp": self.timestamp,
             "lane": self.lane,
+            "objective_scores": dict(self.objective_scores),
+            "per_case_objective_scores": {
+                case_id: dict(scores)
+                for case_id, scores in self.per_case_objective_scores.items()
+            },
         }
         if self.extra:
             out["extra"] = dict(self.extra)
@@ -209,6 +217,9 @@ class ParetoRow:
     @staticmethod
     def from_dict(data: dict[str, Any]) -> ParetoRow:
         # Rows written before lanes existed carry no "lane" key; default to None.
+        raw_per_case_objectives = data.get("per_case_objective_scores", {})
+        if not isinstance(raw_per_case_objectives, dict):
+            raise ValueError("per_case_objective_scores must be a mapping.")
         return ParetoRow(
             candidate_id=str(data["candidate_id"]),
             commit_sha=data.get("commit_sha"),
@@ -222,6 +233,11 @@ class ParetoRow:
             summary=str(data.get("summary", "")),
             timestamp=str(data["timestamp"]),
             lane=data.get("lane"),
+            objective_scores=_finite_objective_scores(data.get("objective_scores", {})),
+            per_case_objective_scores={
+                str(case_id): _finite_objective_scores(scores)
+                for case_id, scores in raw_per_case_objectives.items()
+            },
             extra=dict(data.get("extra", {})),
         )
 
@@ -333,23 +349,36 @@ class ParetoLog:
                 count += 1
         return count
 
-    def front(self) -> list[ParetoRow]:
-        """Return rows that are Pareto-dominant across per-case scores.
+    def front(self, *, mode: str = "instance") -> list[ParetoRow]:
+        """Return the selectable Pareto front with complete matching coordinates.
 
-        A row dominates another if its per-case scores are >= the other's on
-        every shared case and strictly > on at least one. Rows without any
-        overlapping cases are kept (they're incomparable). Higher score = better.
+        Rows must expose identical coordinates for the requested frontier mode;
+        partial rows fail closed instead of being treated as incomparable.
         """
+        if mode not in {"instance", "objective", "hybrid", "cartesian"}:
+            raise ValueError(f"Unknown Pareto frontier mode: {mode!r}.")
         rows = self.selectable_rows()
         if not rows:
             return []
+        coordinates = [_row_coordinates(row, mode) for row in rows]
+        if any(coordinate is None for coordinate in coordinates):
+            raise ValueError(
+                f"{mode} frontier requires complete coordinates for every selectable row."
+            )
+        first_coordinates = set(coordinates[0] or {})
+        if any(
+            set(coordinate or {}) != first_coordinates for coordinate in coordinates[1:]
+        ):
+            raise ValueError(
+                "Pareto frontier rows must have identical coordinate keys; refusing incomparable partial rows."
+            )
 
         front: list[ParetoRow] = []
         for candidate in rows:
             dominated = False
             front_after: list[ParetoRow] = []
             for existing in front:
-                cmp = _dominance(existing.per_case_scores, candidate.per_case_scores)
+                cmp = _row_dominance(existing, candidate, mode=mode)
                 if cmp == "existing":
                     dominated = True
                     front_after.append(existing)
@@ -401,3 +430,60 @@ def _dominance(a: dict[str, float], b: dict[str, float]) -> str | None:
     if b_ge_all and b_gt_any:
         return "candidate"
     return None
+
+
+def _finite_objective_scores(raw: Any) -> dict[str, float]:
+    """Validate named higher-is-better objective coordinates at the ledger edge."""
+    if not isinstance(raw, dict):
+        raise ValueError("objective_scores must be a mapping.")
+    values: dict[str, float] = {}
+    for name, value in raw.items():
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+        ):
+            raise ValueError(f"Objective score {name!r} must be finite numeric.")
+        values[str(name)] = float(value)
+    return values
+
+
+def _row_dominance(
+    existing: ParetoRow, candidate: ParetoRow, *, mode: str
+) -> str | None:
+    """Compare instance/objective/hybrid/cartesian frontier coordinates."""
+    if mode not in {"instance", "objective", "hybrid", "cartesian"}:
+        raise ValueError(
+            "front mode must be instance, objective, hybrid, or cartesian."
+        )
+    left = _row_coordinates(existing, mode)
+    right = _row_coordinates(candidate, mode)
+    if left is None or right is None or set(left) != set(right):
+        return None
+    comparison = _dominance(left, right)
+    if comparison == "existing":
+        return "existing"
+    if comparison == "candidate":
+        return "candidate"
+    return None
+
+
+def _row_coordinates(row: ParetoRow, mode: str) -> dict[str, float] | None:
+    coordinates: dict[str, float] = {}
+    if mode in {"instance", "hybrid"}:
+        coordinates.update(
+            {f"case:{case_id}": score for case_id, score in row.per_case_scores.items()}
+        )
+    if mode in {"objective", "hybrid"}:
+        if not row.objective_scores:
+            return None
+        coordinates.update(
+            {f"objective:{name}": score for name, score in row.objective_scores.items()}
+        )
+    if mode == "cartesian":
+        for case_id, objectives in row.per_case_objective_scores.items():
+            for name, score in objectives.items():
+                coordinates[f"case:{case_id}:objective:{name}"] = score
+        if not coordinates:
+            return None
+    return coordinates or None

--- a/src/pydantic_ai_gepa/engines/base.py
+++ b/src/pydantic_ai_gepa/engines/base.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
+import math
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -35,6 +38,10 @@ class CandidateEvaluation:
     records: list[EvaluationRecord]
     side_info: dict[str, Any]
     num_cases: int
+    objective_scores: dict[str, float] = field(default_factory=dict)
+    per_case_objective_scores: dict[str, dict[str, float]] = field(default_factory=dict)
+    selectable: bool = True
+    per_case_scores: dict[str, float] = field(default_factory=dict)
 
 
 class OptimizationTask:
@@ -52,6 +59,8 @@ class OptimizationTask:
         skills_capabilities: set[SkillCapability] | None = None,
         case_factory: CaseFactory | None = None,
         concurrency: int = 20,
+        test_set: DatasetInput | None = None,
+        evaluation_cache_identity: str | None = None,
     ) -> None:
         """Create an optimization task without eagerly materializing datasets."""
         if concurrency < 1:
@@ -61,11 +70,13 @@ class OptimizationTask:
         self.trainset = trainset
         self.metric = metric
         self.valset = valset
+        self.test_set = test_set
         self.input_type = input_type
         self.skills_fs = skills_fs
         self.skills_capabilities = skills_capabilities
         self.case_factory = case_factory
         self.concurrency = concurrency
+        self.evaluation_cache_identity = evaluation_cache_identity
 
         self._train_loader: DataLoader[Any, Case[Any, Any, Any]] | None = None
         self._val_loader: DataLoader[Any, Case[Any, Any, Any]] | None = None
@@ -74,6 +85,12 @@ class OptimizationTask:
         self._train_loader_lock = asyncio.Lock()
         self._val_loader_lock = asyncio.Lock()
         self._val_cases_lock = asyncio.Lock()
+        self._test_loader: DataLoader[Any, Case[Any, Any, Any]] | None = None
+        self._test_cases: list[Case[Any, Any, Any]] | None = None
+        self._test_loader_lock = asyncio.Lock()
+        self._test_cases_lock = asyncio.Lock()
+        self._evaluation_cache: dict[str, CandidateEvaluation] = {}
+        self._evaluation_cache_lock = asyncio.Lock()
         self._seed_candidate_lock = asyncio.Lock()
 
     async def train_loader(self) -> DataLoader[Any, Case[Any, Any, Any]]:
@@ -115,12 +132,38 @@ class OptimizationTask:
         *,
         budget: BudgetTracker | None = None,
         capture_traces: bool = False,
+        dataset: str = "validation",
+        cache: bool = False,
     ) -> CandidateEvaluation:
-        """Evaluate ``candidate`` on the valset through the shared eval server."""
+        """Evaluate a candidate through the shared eval server.
+
+        ``dataset='test'`` is deliberately reporting-only: engines only receive
+        this task API and composition never invokes it until a final report.
+        Caching is opt-in and requires a caller supplied deterministic evaluator
+        identity; stochastic evaluators must include their seed/control in it.
+        """
+        if dataset not in {"validation", "test"}:
+            raise ValueError("dataset must be 'validation' or 'test'.")
+        cases = await (
+            self._validation_cases()
+            if dataset == "validation"
+            else self._test_cases_for_reporting()
+        )
+        cache_key = self._cache_key(candidate, dataset) if cache else None
+        if cache_key is not None:
+            async with self._evaluation_cache_lock:
+                cached = self._evaluation_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        # Charge before making a call. This closes the evaluate-then-spend race
+        # and means an exhausted budget cannot trigger an invisible evaluator call.
+        if budget is not None:
+            budget.spend(len(cases))
         records = await evaluate_candidate_dataset(
             agent=self.agent,
             metric=self.metric,
-            dataset=await self._validation_cases(),
+            dataset=cases,
             candidate=candidate,
             concurrency=self.concurrency,
             input_type=self.input_type,
@@ -129,18 +172,24 @@ class OptimizationTask:
             skills_capabilities=self.skills_capabilities,
             capture_traces=capture_traces,
         )
-        if budget is not None:
-            budget.spend(len(records))
-
         score = (
             sum(record.score for record in records) / len(records) if records else 0.0
         )
-        return CandidateEvaluation(
+        objectives, per_case_objectives, selectable = _objective_scores(records)
+        result = CandidateEvaluation(
             score=score,
             records=records,
             side_info=_aggregate_side_info(records),
             num_cases=len(records),
+            objective_scores=objectives,
+            per_case_objective_scores=per_case_objectives,
+            selectable=selectable,
+            per_case_scores={record.case_id: record.score for record in records},
         )
+        if cache_key is not None:
+            async with self._evaluation_cache_lock:
+                self._evaluation_cache.setdefault(cache_key, result)
+        return result
 
     async def _validation_cases(self) -> Sequence[Case[Any, Any, Any]]:
         """Materialize and memoize the validation loader's cases for evaluation."""
@@ -150,6 +199,55 @@ class OptimizationTask:
                     loader = await self.val_loader()
                     self._val_cases = await loader.fetch(await loader.all_ids())
         return self._val_cases
+
+    async def _test_cases_for_reporting(self) -> Sequence[Case[Any, Any, Any]]:
+        """Materialize the optional held-out reporting set, never used by engines."""
+        if self.test_set is None:
+            raise ValueError("This task has no test_set.")
+        if self._test_cases is None:
+            async with self._test_cases_lock:
+                if self._test_cases is None:
+                    if self._test_loader is None:
+                        async with self._test_loader_lock:
+                            if self._test_loader is None:
+                                self._test_loader = await resolve_dataset(
+                                    self.test_set, name="test_set"
+                                )
+                    self._test_cases = await self._test_loader.fetch(
+                        await self._test_loader.all_ids()
+                    )
+        return self._test_cases
+
+    def _cache_key(self, candidate: CandidateMap, dataset: str) -> str | None:
+        if self.evaluation_cache_identity is None:
+            raise ValueError(
+                "Evaluation caching requires evaluation_cache_identity; include a deterministic evaluator version and seed."
+            )
+        payload = json.dumps(
+            {
+                "identity": self.evaluation_cache_identity,
+                "dataset": dataset,
+                "cases": [
+                    {
+                        "id": case.name,
+                        "inputs": repr(case.inputs),
+                        "expected_output": repr(case.expected_output),
+                        "metadata": repr(case.metadata),
+                    }
+                    for case in (
+                        self._val_cases if dataset == "validation" else self._test_cases
+                    )
+                    or []
+                ],
+                "candidate": {
+                    name: value.model_dump(mode="json")
+                    for name, value in sorted(candidate.items())
+                },
+            },
+            sort_keys=True,
+            default=str,
+        ).encode()
+        return hashlib.sha256(payload).hexdigest()
 
 
 def _aggregate_side_info(records: Sequence[EvaluationRecord]) -> dict[str, Any]:
@@ -171,6 +269,69 @@ def _aggregate_side_info(records: Sequence[EvaluationRecord]) -> dict[str, Any]:
     if feedback:
         side_info["feedback"] = feedback
     return side_info
+
+
+def _objective_scores(
+    records: Sequence[EvaluationRecord],
+) -> tuple[dict[str, float], dict[str, dict[str, float]], bool]:
+    """Extract finite higher-is-better objectives from ``side_info['scores']``.
+
+    The regular scalar score remains the compatibility/reporting score.  An
+    invalid objective is a caller error rather than silently becoming a NaN
+    frontier coordinate.  A metric can mark a result non-selectable with
+    ``side_info['selectable'] = False`` (for infrastructure-invalid outcomes).
+    """
+    values: dict[str, list[float]] = {}
+    per_case: dict[str, dict[str, float]] = {}
+    selectable = True
+    objective_key_sets: list[set[str] | None] = []
+    for record in records:
+        info = record.payload.get("side_info")
+        if not isinstance(info, dict):
+            info = record.payload.get("metric_side_info")
+        if not isinstance(info, dict):
+            info = getattr(record.payload.get("trajectory"), "metric_side_info", None)
+        if not isinstance(info, dict):
+            objective_key_sets.append(None)
+            continue
+        if info.get("selectable") is False or info.get("infrastructure_valid") is False:
+            selectable = False
+        raw_scores = info.get("scores")
+        if raw_scores is None:
+            objective_key_sets.append(None)
+            continue
+        if not isinstance(raw_scores, dict):
+            raise ValueError(
+                "MetricResult.side_info['scores'] must be a mapping of names to finite numbers."
+            )
+        case_scores: dict[str, float] = {}
+        objective_key_sets.append({str(name) for name in raw_scores})
+        for name, raw in raw_scores.items():
+            if (
+                isinstance(raw, bool)
+                or not isinstance(raw, (int, float))
+                or not math.isfinite(float(raw))
+            ):
+                raise ValueError(
+                    f"Objective score {name!r} for case {record.case_id!r} must be finite numeric."
+                )
+            value = float(raw)
+            key = str(name)
+            values.setdefault(key, []).append(value)
+            case_scores[key] = value
+        if case_scores:
+            per_case[record.case_id] = case_scores
+    if any(keys is not None for keys in objective_key_sets):
+        first = objective_key_sets[0]
+        if first is None or any(keys != first for keys in objective_key_sets[1:]):
+            raise ValueError(
+                "MetricResult.side_info['scores'] must expose identical objective keys for every evaluated case."
+            )
+    return (
+        {name: sum(scores) / len(scores) for name, scores in values.items()},
+        per_case,
+        selectable,
+    )
 
 
 class EngineConfig(BaseModel):
@@ -245,6 +406,38 @@ class BudgetTracker:
                 f"requested {n} with {self.remaining} remaining."
             )
         self._spent += n
+
+    def preflight(self, n: int) -> None:
+        """Fail before an evaluator call when ``n`` calls are not affordable."""
+        if n < 0:
+            raise ValueError("n must be greater than or equal to zero.")
+        if n > self.remaining:
+            raise BudgetExhausted(
+                f"Metric-call budget exhausted: requested {n} with {self.remaining} remaining."
+            )
+
+    def refund(self, n: int) -> None:
+        """Return a pre-reserved amount that was not actually consumed."""
+        if n < 0 or n > self._spent:
+            raise ValueError("Cannot refund more metric calls than have been spent.")
+        self._spent -= n
+
+    def reserve_slice(self, n: int) -> "BudgetTracker":
+        """Reserve an isolated child budget before concurrent work starts.
+
+        The parent is charged immediately; callers release unused capacity with
+        :meth:`release_slice` after the engine finishes. This makes concurrent
+        composition deterministic and prevents two engines from racing for the
+        final calls.
+        """
+        self.spend(n)
+        return BudgetTracker(n)
+
+    def release_slice(self, slice_budget: "BudgetTracker") -> None:
+        """Return unused capacity from a completed child slice to this budget."""
+        unused = slice_budget.remaining
+        if unused:
+            self._spent -= unused
 
     def check(self) -> None:
         """Raise if the shared metric-call budget has been exhausted."""

--- a/src/pydantic_ai_gepa/engines/coding_agent_engine.py
+++ b/src/pydantic_ai_gepa/engines/coding_agent_engine.py
@@ -111,6 +111,29 @@ class CodingAgentEngine:
             )
             epoch += 1
             minibatch = await train_loader.fetch(minibatch_ids)
+            # A baseline is an indivisible provider-facing operation.  Do not
+            # let `_affordable_repetitions` turn an unaffordable first batch
+            # into one attempted evaluation: `_evaluate_minibatch` reserves
+            # before it invokes the provider, so stopping here is both clean
+            # and honest.
+            if (
+                len(minibatch) > budget.remaining
+                or len(minibatch) > engine_budget.remaining
+            ):
+                history.append(
+                    EngineEvent(
+                        kind="budget_exhausted",
+                        message="No complete baseline minibatch is affordable.",
+                        data={
+                            "stage": "baseline_minibatch",
+                            "requested": len(minibatch),
+                            "budget_remaining": budget.remaining,
+                            "engine_budget_remaining": engine_budget.remaining,
+                        },
+                    )
+                )
+                stop_reason = "budget_exhausted"
+                break
             effective_max_repetitions = _affordable_repetitions(
                 requested=acceptance_max_repetitions,
                 case_count=len(minibatch),
@@ -120,12 +143,19 @@ class CodingAgentEngine:
             baseline_batches: list[list[EvaluationRecord]] = []
             baseline_budget_exhausted = False
             for _ in range(effective_max_repetitions):
-                baseline_records = await self._evaluate_minibatch(
-                    task=task,
-                    candidate=best,
-                    minibatch=minibatch,
-                    concurrency=concurrency,
-                )
+                try:
+                    baseline_records = await self._evaluate_minibatch(
+                        task=task,
+                        candidate=best,
+                        minibatch=minibatch,
+                        concurrency=concurrency,
+                        budget=budget,
+                        engine_budget=engine_budget,
+                    )
+                except BudgetExhausted:
+                    baseline_budget_exhausted = True
+                    stop_reason = "budget_exhausted"
+                    break
                 if not self._spend_or_record_overshoot(
                     budget=budget,
                     engine_budget=engine_budget,
@@ -194,7 +224,12 @@ class CodingAgentEngine:
                         candidate=proposal,
                         minibatch=minibatch,
                         concurrency=concurrency,
+                        budget=budget,
+                        engine_budget=engine_budget,
                     )
+                except BudgetExhausted:
+                    stop_reason = "budget_exhausted"
+                    break
                 except Exception as exc:
                     raise RuntimeError(
                         "Coding-agent proposal evaluation failed."
@@ -222,7 +257,7 @@ class CodingAgentEngine:
                     break
 
             if comparison_result is None:
-                if stop_reason == "budget_overshoot":
+                if stop_reason in {"budget_overshoot", "budget_exhausted"}:
                     break
                 raise RuntimeError(
                     "Coding-agent comparison did not collect enough proposal samples."
@@ -288,8 +323,17 @@ class CodingAgentEngine:
         candidate: CandidateMap,
         minibatch: Sequence[Case[Any, Any, Any]],
         concurrency: int,
+        budget: BudgetTracker,
+        engine_budget: BudgetTracker,
     ) -> list[EvaluationRecord]:
         """Evaluate one candidate on the explicitly selected minibatch."""
+        budget.preflight(len(minibatch))
+        engine_budget.preflight(len(minibatch))
+        # Reserve before the provider invocation. A rollout that raises after
+        # contacting a provider remains accounted; only never-started calls
+        # are rejected by preflight.
+        budget.spend(len(minibatch))
+        engine_budget.spend(len(minibatch))
         return await evaluate_candidate_dataset(
             agent=task.agent,
             metric=task.metric,
@@ -314,28 +358,27 @@ class CodingAgentEngine:
     ) -> tuple[float, bool]:
         """Score the winner on the valset and charge that fair comparison.
 
-        The score is evaluated before spending so it remains available for the
-        result when the final comparison itself would exceed the shared budget.
-        In that overshoot case the budget remains unchanged and the event makes
-        the uncharged evaluation explicit to a composing caller.
+        Both budgets are reserved before evaluator invocation. If a provider
+        raises after starting a rollout, the call remains accounted; a
+        preflight failure makes no evaluator call.
         """
-        final_evaluation = await task.evaluate(candidate, budget=None)
-        if final_evaluation.num_cases > engine_budget.remaining:
+        case_count = len(await task._validation_cases())
+        if case_count > engine_budget.remaining:
             history.append(
                 EngineEvent(
                     kind="budget_overshoot",
                     message="Final valset evaluation exceeded the engine metric-call budget.",
                     data={
                         "stage": "final_valset",
-                        "requested": final_evaluation.num_cases,
+                        "requested": case_count,
                         "budget_remaining": budget.remaining,
                         "engine_budget_remaining": engine_budget.remaining,
                     },
                 )
             )
-            return final_evaluation.score, False
+            return 0.0, False
         try:
-            budget.spend(final_evaluation.num_cases)
+            budget.preflight(case_count)
         except BudgetExhausted:
             history.append(
                 EngineEvent(
@@ -343,14 +386,15 @@ class CodingAgentEngine:
                     message="Final valset evaluation exceeded the shared metric-call budget.",
                     data={
                         "stage": "final_valset",
-                        "requested": final_evaluation.num_cases,
+                        "requested": case_count,
                         "budget_remaining": budget.remaining,
                         "engine_budget_remaining": engine_budget.remaining,
                     },
                 )
             )
-            return final_evaluation.score, False
-        engine_budget.spend(final_evaluation.num_cases)
+            return 0.0, False
+        engine_budget.spend(case_count)
+        final_evaluation = await task.evaluate(candidate, budget=budget)
         return final_evaluation.score, True
 
     def _spend_or_record_overshoot(
@@ -363,37 +407,8 @@ class CodingAgentEngine:
         records: Sequence[EvaluationRecord],
     ) -> bool:
         """Charge an evaluation or record the budget overshoot that stops it."""
-        if len(records) > engine_budget.remaining:
-            history.append(
-                EngineEvent(
-                    kind="budget_overshoot",
-                    message="Minibatch evaluation exceeded the engine metric-call budget.",
-                    data={
-                        "stage": stage,
-                        "requested": len(records),
-                        "budget_remaining": budget.remaining,
-                        "engine_budget_remaining": engine_budget.remaining,
-                    },
-                )
-            )
-            return False
-        try:
-            budget.spend(len(records))
-        except BudgetExhausted:
-            history.append(
-                EngineEvent(
-                    kind="budget_overshoot",
-                    message="Minibatch evaluation exceeded the shared metric-call budget.",
-                    data={
-                        "stage": stage,
-                        "requested": len(records),
-                        "budget_remaining": budget.remaining,
-                        "engine_budget_remaining": engine_budget.remaining,
-                    },
-                )
-            )
-            return False
-        engine_budget.spend(len(records))
+        # `_evaluate_minibatch` reserved both budgets before invoking the
+        # evaluator. Keep this helper for the existing history call sites.
         return True
 
     def _option(self, name: str, default: Any) -> Any:

--- a/src/pydantic_ai_gepa/engines/gepa_engine.py
+++ b/src/pydantic_ai_gepa/engines/gepa_engine.py
@@ -13,7 +13,6 @@ from ..gepa_graph.models import CandidateMap, GepaConfig, GepaResult, GepaState
 from ..runner import _resolve_candidate_selector, _resolve_component_selector
 from ..types import ReflectionConfig
 from .base import (
-    BudgetExhausted,
     BudgetTracker,
     EngineConfig,
     EngineEvent,
@@ -89,6 +88,11 @@ class GepaEngine:
             memory_exporter=None,
         )
         graph = create_gepa_graph(config=gepa_config)
+        # Reserve before the graph can invoke a rollout. The graph's own cap
+        # is identical; unused capacity is refunded after its exact telemetry
+        # is known, so result accounting remains honest.
+        reserved = gepa_config.max_evaluations
+        budget.spend(reserved)
 
         try:
             run_output: GepaResult | None = None
@@ -105,19 +109,11 @@ class GepaEngine:
 
         num_metric_calls = state.total_evaluations
         history: list[EngineEvent] = []
-        try:
-            budget.spend(num_metric_calls)
-        except BudgetExhausted:
-            history.append(
-                EngineEvent(
-                    kind="budget_overshoot",
-                    message="GEPA completed after exceeding its allocated budget slice.",
-                    data={
-                        "total_evaluations": num_metric_calls,
-                        "budget_remaining_before_spend": remaining_budget,
-                    },
-                )
+        if num_metric_calls > reserved:
+            raise RuntimeError(
+                f"GEPA exceeded its pre-reserved slice ({num_metric_calls}>{reserved})."
             )
+        budget.refund(reserved - num_metric_calls)
 
         best_candidate = _candidate_map(gepa_result.best_candidate, seed_candidate)
         history.append(

--- a/tests/cli/test_runs.py
+++ b/tests/cli/test_runs.py
@@ -263,7 +263,12 @@ def test_pareto_log_concurrent_appends(tmp_path: Path) -> None:
 
 
 def _row(
-    candidate_id: str, scores: dict[str, float], status: str = "evaluated"
+    candidate_id: str,
+    scores: dict[str, float],
+    status: str = "evaluated",
+    *,
+    objective_scores: dict[str, float] | None = None,
+    per_case_objective_scores: dict[str, dict[str, float]] | None = None,
 ) -> ParetoRow:
     return ParetoRow(
         candidate_id=candidate_id,
@@ -275,6 +280,8 @@ def _row(
         status=status,
         summary=f"Row {candidate_id}",
         timestamp=utc_now_iso(),
+        objective_scores=objective_scores or {},
+        per_case_objective_scores=per_case_objective_scores or {},
     )
 
 
@@ -350,6 +357,79 @@ def test_pareto_front_excludes_non_selectable_infrastructure_rows(
     assert log.count_rows() == 2
     assert [row.candidate_id for row in log.selectable_rows()] == ["healthy"]
     assert [row.candidate_id for row in log.front()] == ["healthy"]
+
+
+def test_pareto_front_supports_objective_hybrid_and_cartesian_coordinates(
+    tmp_path: Path,
+) -> None:
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    log = ParetoLog(run, tmp_path)
+    weaker = _row(
+        "weaker",
+        {"a": 0.5, "b": 0.5},
+        objective_scores={"quality": 0.2},
+        per_case_objective_scores={
+            "a": {"quality": 0.2},
+            "b": {"quality": 0.2},
+        },
+    )
+    stronger = _row(
+        "stronger",
+        {"a": 0.6, "b": 0.6},
+        objective_scores={"quality": 0.8},
+        per_case_objective_scores={
+            "a": {"quality": 0.8},
+            "b": {"quality": 0.8},
+        },
+    )
+    log.append(weaker)
+    log.append(stronger)
+
+    for mode in ("objective", "hybrid", "cartesian"):
+        assert [row.candidate_id for row in log.front(mode=mode)] == ["stronger"]
+
+
+@pytest.mark.parametrize("mode", ["objective", "hybrid", "cartesian"])
+def test_pareto_front_fails_closed_for_missing_or_inconsistent_coordinates(
+    tmp_path: Path, mode: str
+) -> None:
+    ensure_layout(tmp_path)
+    run = new_run_id()
+    log = ParetoLog(run, tmp_path)
+    complete = _row(
+        "complete",
+        {"a": 0.5},
+        objective_scores={"quality": 0.5},
+        per_case_objective_scores={"a": {"quality": 0.5}},
+    )
+    incomplete = _row("incomplete", {"a": 0.5})
+    if mode == "cartesian":
+        incomplete = _row("incomplete", {"a": 0.5}, objective_scores={"quality": 0.5})
+    elif mode == "hybrid":
+        incomplete = _row("incomplete", {"a": 0.5}, objective_scores={"different": 0.5})
+    log.append(complete)
+    log.append(incomplete)
+
+    with pytest.raises(ValueError):
+        log.front(mode=mode)
+
+
+def test_pareto_front_rejects_unknown_mode(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    log = ParetoLog(new_run_id(), tmp_path)
+    log.append(_row("candidate", {"a": 1.0}))
+
+    with pytest.raises(ValueError, match="Unknown Pareto frontier mode"):
+        log.front(mode="not-a-mode")
+
+
+def test_pareto_row_rejects_non_mapping_per_case_objectives() -> None:
+    data = _row("candidate", {"a": 1.0}).to_dict()
+    data["per_case_objective_scores"] = ["not-a-mapping"]
+
+    with pytest.raises(ValueError, match="per_case_objective_scores"):
+        ParetoRow.from_dict(data)
 
 
 def test_pareto_persists_full_schema(tmp_path: Path) -> None:

--- a/tests/engines/test_base.py
+++ b/tests/engines/test_base.py
@@ -16,6 +16,7 @@ from pydantic_ai_gepa.engines.base import (
     EngineConfig,
     OptimizationTask,
 )
+from pydantic_ai_gepa.cli.eval import _objective_scores as cli_objective_scores
 from pydantic_ai_gepa.evaluation import EvaluationRecord
 from pydantic_ai_gepa.types import MetricResult, RolloutOutput
 
@@ -120,3 +121,46 @@ async def test_optimization_task_aggregates_payload_side_info(
         "cases": [{"case_id": "case", "side_info": {"hint": "be concise"}}],
         "feedback": ["try again"],
     }
+
+
+@pytest.mark.asyncio
+async def test_objective_scores_require_identical_keys_for_every_case(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(TestModel(custom_output_text="ok"), instructions="seed")
+    cases = [
+        Case(name="one", inputs="one", expected_output="ok"),
+        Case(name="two", inputs="two", expected_output="ok"),
+    ]
+    task = OptimizationTask(
+        agent=agent,
+        trainset=cases,
+        valset=cases,
+        metric=lambda case, output: MetricResult(score=1.0),
+    )
+    records = [
+        EvaluationRecord(
+            case_id="one",
+            score=1.0,
+            feedback=None,
+            payload={"side_info": {"scores": {"quality": 1.0}}},
+        ),
+        EvaluationRecord(
+            case_id="two",
+            score=1.0,
+            feedback=None,
+            payload={"side_info": {"scores": {"safety": 1.0}}},
+        ),
+    ]
+
+    async def fake_evaluate_candidate_dataset(**kwargs: Any) -> list[EvaluationRecord]:
+        return records
+
+    monkeypatch.setattr(
+        "pydantic_ai_gepa.engines.base.evaluate_candidate_dataset",
+        fake_evaluate_candidate_dataset,
+    )
+    with pytest.raises(ValueError, match="identical objective keys"):
+        await task.evaluate(await task.seed_candidate())
+    with pytest.raises(Exception, match="identical objective keys"):
+        cli_objective_scores(records)

--- a/tests/engines/test_coding_agent_engine.py
+++ b/tests/engines/test_coding_agent_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from typing import Any
 
 import pytest
@@ -217,6 +218,47 @@ async def test_coding_agent_engine_stops_after_a_budget_overshoot() -> None:
     assert result.best_candidate["instructions"].text == "seed"
     assert result.num_metric_calls == budget.spent == 3
     assert any(event.kind == "budget_overshoot" for event in result.history)
+
+
+@pytest.mark.asyncio
+async def test_coding_agent_engine_stops_cleanly_when_first_minibatch_is_unaffordable() -> (
+    None
+):
+    """A preflight failure must not leak a provider call or raise from run()."""
+
+    metric_calls = 0
+    proposer_calls = 0
+    task = _task(case_count=2)
+    original_metric = task.metric
+
+    def counted_metric(
+        case: Case[str, str, Any], output: RolloutOutput[Any]
+    ) -> MetricResult | Awaitable[MetricResult]:
+        nonlocal metric_calls
+        metric_calls += 1
+        return original_metric(case, output)
+
+    task.metric = counted_metric
+
+    async def propose(context: ReflectionContext) -> CandidateMap:
+        del context
+        nonlocal proposer_calls
+        proposer_calls += 1
+        return _candidate("correct")
+
+    config = EngineConfig(
+        engine="coding_agent",
+        max_metric_calls=1,
+        engine_config={"propose": propose, "minibatch_size": 2},
+    )
+    budget = BudgetTracker(1)
+
+    result = await get_engine("coding_agent", config).run(task, config, budget)
+
+    assert result.best_candidate["instructions"].text == "seed"
+    assert result.num_metric_calls == budget.spent == 0
+    assert metric_calls == proposer_calls == 0
+    assert any(event.kind == "budget_exhausted" for event in result.history)
 
 
 @pytest.mark.parametrize("propose", [None, "not callable", object()])


### PR DESCRIPTION
## Summary
- add objective-aware engine accounting
- fail closed on inconsistent objective coordinates
- make candidate evaluation and Pareto selection explicit

## Stack
2 of 5; depends on #34.

## Verification
- full stack: 601 tests passed
- Ruff format and lint passed
- changed-file Pyright passed