### PR TITLE
Add two-phase Omni composition

### DIFF
--- a/src/pydantic_ai_gepa/__init__.py
+++ b/src/pydantic_ai_gepa/__init__.py
@@ -20,8 +20,12 @@ from .inspection import (
 from .exceptions import UsageBudgetExceeded
 from .runner import GepaOptimizationResult, optimize_agent
 from .compose import (
+    FairVote,
+    OmniPlan,
     PipelineResult,
+    optimize_adaptive_sequential,
     optimize_best_of,
+    optimize_omni,
     optimize_parallel,
     optimize_sequential,
     optimize_vote,
@@ -71,10 +75,14 @@ __all__ = [
     "AcceptanceComparison",
     "compare_candidate_samples",
     "optimize_parallel",
+    "optimize_omni",
+    "optimize_adaptive_sequential",
     "optimize_best_of",
     "optimize_sequential",
     "optimize_vote",
     "PipelineResult",
+    "OmniPlan",
+    "FairVote",
     "GepaOptimizationResult",
     "Adapter",
     "AgentAdapter",

--- a/src/pydantic_ai_gepa/compose.py
+++ b/src/pydantic_ai_gepa/compose.py
@@ -1,15 +1,18 @@
-"""Helpers for composing optimization engines under one shared budget."""
+"""Composable, budget-accounted optimization pipelines, including Omni."""
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
-from typing import Any, cast
+import math
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
+from .acceptance import compare_candidate_samples
 from .engines import (
     BudgetTracker,
+    CandidateEvaluation,
     EngineConfig,
     EngineEvent,
     EngineResult,
@@ -19,16 +22,96 @@ from .engines import (
 from .gepa_graph.models import CandidateMap
 
 
+class FairVote(BaseModel):
+    """Repeated matched samples and the selection decision for one candidate."""
+
+    candidate_index: int
+    samples: list[float]
+    mean_score: float
+    objective_scores: dict[str, float] = Field(default_factory=dict)
+    per_case_scores: dict[str, float] = Field(default_factory=dict)
+    per_case_objective_scores: dict[str, dict[str, float]] = Field(default_factory=dict)
+    selectable: bool = True
+
+
 class PipelineResult(BaseModel):
-    """Results of a composed engine run and its fairly selected winner."""
+    """Inspectable result of a composed run.
+
+    ``total_metric_calls`` retains the historic optimization-only meaning.
+    Comparison and reporting calls are separately visible and the sum is
+    provided as ``accounted_metric_calls`` so no evaluator work is hidden.
+    """
 
     results: list[EngineResult]
     best: EngineResult
     best_index: int
     fair_scores: list[float]
     total_metric_calls: int
+    comparison_metric_calls: int = 0
+    reporting_metric_calls: int = 0
+    fair_votes: list[FairVote] = Field(default_factory=list)
+    decision: dict[str, Any] = Field(default_factory=dict)
+    test_score: float | None = None
+    phases: list[dict[str, Any]] = Field(default_factory=list)
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    @property
+    def accounted_metric_calls(self) -> int:
+        return (
+            self.total_metric_calls
+            + self.comparison_metric_calls
+            + self.reporting_metric_calls
+        )
+
+
+class OmniPlan(BaseModel):
+    """Explicit two-phase Omni plan.
+
+    Phase-one configurations each own their fixed matched slice via
+    ``EngineConfig.max_metric_calls``.  The phase-two configuration creates a
+    fresh engine instance from the fairly selected winner.  Comparison and
+    reporting budget are separate named currencies, rather than free calls.
+    """
+
+    phase_one: list[EngineConfig]
+    phase_two: EngineConfig
+    phase_one_metric_calls: int
+    phase_two_metric_calls: int
+    comparison_metric_calls: int | None = None
+    continuation_comparison_metric_calls: int | None = None
+    reporting_metric_calls: int | None = None
+    fair_vote_repetitions: int = Field(default=3, ge=1, le=5)
+    fair_vote_max_repetitions: int = Field(default=5, ge=1, le=5)
+    acceptance_confidence: float = Field(default=0.9, gt=0.0, lt=1.0)
+    acceptance_min_delta: float = Field(default=0.0, ge=0.0)
+    selection_mode: Literal["instance", "objective", "hybrid", "cartesian"] = "instance"
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.phase_one:
+            raise ValueError("Omni phase_one must contain at least one engine.")
+        if self.fair_vote_max_repetitions < self.fair_vote_repetitions:
+            raise ValueError(
+                "fair_vote_max_repetitions must be >= fair_vote_repetitions."
+            )
+        if not math.isfinite(self.acceptance_min_delta):
+            raise ValueError("acceptance_min_delta must be finite.")
+        if (
+            sum(config.max_metric_calls for config in self.phase_one)
+            != self.phase_one_metric_calls
+        ):
+            raise ValueError(
+                "phase_one_metric_calls must equal the sum of phase-one engine slices; "
+                "matched phase-one slices are explicit."
+            )
+        if self.phase_two.max_metric_calls != self.phase_two_metric_calls:
+            raise ValueError(
+                "phase_two_metric_calls must equal phase_two.max_metric_calls."
+            )
+        if len({config.max_metric_calls for config in self.phase_one}) != 1:
+            raise ValueError("All phase-one engine slices must be matched.")
+        if len({config.engine for config in self.phase_one}) != len(self.phase_one):
+            raise ValueError("Phase-one Omni engines must be distinct families.")
 
 
 class _SeededTask:
@@ -39,12 +122,68 @@ class _SeededTask:
         self._seed = seed
 
     async def seed_candidate(self) -> CandidateMap:
-        """Return the candidate adopted by the preceding pipeline stage."""
         return self._seed
 
     def __getattr__(self, name: str) -> Any:
-        """Forward all non-seed task operations to the wrapped task."""
         return getattr(self._task, name)
+
+
+class _EngineTaskView:
+    """A capability view that prevents engines from accessing held-out data."""
+
+    def __init__(self, task: OptimizationTask) -> None:
+        self.__task = task
+
+    async def seed_candidate(self) -> CandidateMap:
+        return await self.__task.seed_candidate()
+
+    async def train_loader(self) -> Any:
+        return await self.__task.train_loader()
+
+    async def val_loader(self) -> Any:
+        return await self.__task.val_loader()
+
+    @property
+    def agent(self) -> Any:
+        return self.__task.agent
+
+    @property
+    def metric(self) -> Any:
+        return self.__task.metric
+
+    @property
+    def input_type(self) -> Any:
+        return self.__task.input_type
+
+    @property
+    def skills_fs(self) -> Any:
+        return self.__task.skills_fs
+
+    @property
+    def skills_capabilities(self) -> Any:
+        return self.__task.skills_capabilities
+
+    @property
+    def case_factory(self) -> Any:
+        return self.__task.case_factory
+
+    @property
+    def concurrency(self) -> int:
+        return self.__task.concurrency
+
+    async def evaluate(
+        self, candidate: CandidateMap, **kwargs: Any
+    ) -> CandidateEvaluation:
+        if kwargs.pop("dataset", "validation") != "validation":
+            raise PermissionError("Engines cannot access the reporting-only test_set.")
+        return await self.__task.evaluate(candidate, **kwargs)
+
+    @property
+    def test_set(self) -> None:
+        return None
+
+
+SelectionRule = Callable[[Sequence[FairVote]], int]
 
 
 async def optimize_parallel(
@@ -53,13 +192,9 @@ async def optimize_parallel(
     *,
     max_metric_calls: int,
 ) -> list[EngineResult]:
-    """Run configured engines concurrently against one shared metric budget.
-
-    Failures propagate from :func:`asyncio.gather`: a failed engine makes the
-    pipeline fail loudly instead of silently returning a partial comparison.
-    """
+    """Run engines concurrently in pre-reserved isolated budget slices."""
     budget = BudgetTracker(max_metric_calls)
-    return await _run_parallel(task, configs, budget)
+    return await _run_parallel(task, configs, budget, legacy_fallback=True)
 
 
 async def optimize_best_of(
@@ -67,16 +202,38 @@ async def optimize_best_of(
     configs: Sequence[EngineConfig],
     *,
     max_metric_calls: int,
+    comparison_metric_calls: int | None = None,
+    fair_vote_repetitions: int = 1,
+    fair_vote_max_repetitions: int = 1,
+    selection_mode: Literal[
+        "instance", "objective", "hybrid", "cartesian"
+    ] = "instance",
+    selection_rule: SelectionRule | None = None,
+    acceptance_confidence: float = 0.9,
+    acceptance_min_delta: float = 0.0,
 ) -> PipelineResult:
-    """Run engines in parallel and choose the highest fair valset score.
-
-    Fair evaluations are intentionally uncharged, matching coding-agent final
-    evaluation semantics and ensuring engines are compared on the same valset.
-    """
+    """Parallel exploration plus a charged repeated matched comparison."""
+    await _require_comparison_budget(
+        task,
+        candidates=len(configs),
+        repetitions=fair_vote_max_repetitions,
+        requested=comparison_metric_calls,
+    )
     budget = BudgetTracker(max_metric_calls)
-    results = await _run_parallel(task, configs, budget)
-    best_index, fair_scores = await _select_fair_winner(task, results)
-    return _pipeline_result(results, best_index, fair_scores, budget)
+    results = await _run_parallel(task, configs, budget, legacy_fallback=True)
+    winner, votes, comparison_budget, decision = await _select_fair_winner(
+        task,
+        results,
+        metric_calls=comparison_metric_calls,
+        repetitions=fair_vote_repetitions,
+        max_repetitions=fair_vote_max_repetitions,
+        mode=selection_mode,
+        selection_rule=selection_rule,
+        confidence=acceptance_confidence,
+        min_delta=acceptance_min_delta,
+        baseline_index=None,
+    )
+    return _pipeline_result(results, winner, votes, budget, comparison_budget, decision)
 
 
 async def optimize_sequential(
@@ -84,19 +241,24 @@ async def optimize_sequential(
     configs: Sequence[EngineConfig],
     *,
     max_metric_calls: int,
+    comparison_metric_calls: int | None = None,
 ) -> PipelineResult:
-    """Run engines in order, seeding each from the last non-regressing result.
-
-    Each stage and its incoming seed are evaluated on the valset without
-    charging the optimization budget.  A lower-scoring stage is not adopted as
-    the next seed, which keeps the chain monotonic under the shared evaluator.
-    """
+    """Run fresh sequential stages while never adopting a regressing seed."""
     if not configs:
         raise ValueError("At least one engine config is required.")
-
     budget = BudgetTracker(max_metric_calls)
+    comparison_budget = BudgetTracker(
+        await _require_comparison_budget(
+            task,
+            candidates=len(configs),
+            repetitions=1,
+            requested=comparison_metric_calls,
+            include_seed=True,
+        )
+    )
     seed = await task.seed_candidate()
-    seed_score = (await task.evaluate(seed, budget=None)).score
+    seed_evaluation = await task.evaluate(seed, budget=comparison_budget)
+    seed_score = seed_evaluation.score
     adopted_result = EngineResult(
         engine="seed",
         best_candidate=seed,
@@ -106,30 +268,68 @@ async def optimize_sequential(
     )
     adopted_index = -1
     results: list[EngineResult] = []
-    fair_scores: list[float] = []
-
+    votes: list[FairVote] = []
+    phases: list[dict[str, Any]] = []
     for index, config in enumerate(configs):
-        stage_task: OptimizationTask
-        if index == 0:
-            stage_task = task
-        else:
-            stage_task = cast(OptimizationTask, _SeededTask(task, seed))
-        result = await get_engine(config.engine, config).run(stage_task, config, budget)
+        # A stage slice is reserved independently. It cannot steal capacity
+        # allocated to later stages, which keeps accounting deterministic.
+        if budget.remaining == 0:
+            phases.append(
+                {"stage": index, "engine": config.engine, "skipped": "budget_exhausted"}
+            )
+            break
+        slice_size = min(config.max_metric_calls, budget.remaining)
+        local = budget.reserve_slice(slice_size)
+        try:
+            stage_task = cast(
+                OptimizationTask,
+                _SeededTask(cast(OptimizationTask, _EngineTaskView(task)), seed),
+            )
+            result = await get_engine(config.engine, config).run(
+                stage_task, config, local
+            )
+            _reconcile_engine_result(config, result, local)
+        finally:
+            budget.release_slice(local)
         results.append(result)
-        fair_score = (await task.evaluate(result.best_candidate, budget=None)).score
-        fair_scores.append(fair_score)
-        if fair_score >= seed_score:
-            seed = result.best_candidate
-            seed_score = fair_score
-            adopted_result = result
-            adopted_index = index
-
+        evaluation = await task.evaluate(
+            result.best_candidate, budget=comparison_budget
+        )
+        vote = FairVote(
+            candidate_index=index,
+            samples=[evaluation.score],
+            mean_score=evaluation.score,
+            objective_scores=evaluation.objective_scores,
+            selectable=evaluation.selectable,
+        )
+        votes.append(vote)
+        adopted = evaluation.selectable and evaluation.score >= seed_score
+        phases.append(
+            {
+                "stage": index,
+                "engine": config.engine,
+                "adopted": adopted,
+                "seed_score": seed_score,
+                "score": evaluation.score,
+            }
+        )
+        if adopted:
+            seed, seed_score, adopted_result, adopted_index = (
+                result.best_candidate,
+                evaluation.score,
+                result,
+                index,
+            )
     return PipelineResult(
         results=results,
         best=adopted_result,
         best_index=adopted_index,
-        fair_scores=fair_scores,
+        fair_scores=[vote.mean_score for vote in votes],
         total_metric_calls=budget.spent,
+        comparison_metric_calls=comparison_budget.spent,
+        fair_votes=votes,
+        decision={"kind": "monotonic_sequential", "seed_score": seed_score},
+        phases=phases,
     )
 
 
@@ -138,70 +338,771 @@ async def optimize_vote(
     configs: Sequence[EngineConfig],
     *,
     max_metric_calls: int,
+    comparison_metric_calls: int | None = None,
+    fair_vote_repetitions: int = 1,
+    fair_vote_max_repetitions: int = 1,
 ) -> PipelineResult:
-    """Run engines in parallel and select a winner by an uncharged valset vote.
+    """Alias for a repeated, matched, charged cross-engine vote."""
+    return await optimize_best_of(
+        task,
+        configs,
+        max_metric_calls=max_metric_calls,
+        comparison_metric_calls=comparison_metric_calls,
+        fair_vote_repetitions=fair_vote_repetitions,
+        fair_vote_max_repetitions=fair_vote_max_repetitions,
+    )
 
-    This shares the fair-selection implementation with ``optimize_best_of``;
-    the APIs differ in intent, with this helper emphasizing the re-evaluation
-    vote as the selection mechanism.
-    """
+
+async def optimize_omni(
+    task: OptimizationTask,
+    plan: OmniPlan,
+    *,
+    selection_rule: SelectionRule | None = None,
+) -> PipelineResult:
+    """Run the first-class Omni explore → fair-vote → fresh-continuation flow."""
+    # Validate every named non-optimization evaluator budget before any engine
+    # or rollout can start. An underfunded fair vote/report is a plan error,
+    # never a partially optimized run.
+    await _require_comparison_budget(
+        task,
+        candidates=len(plan.phase_one) + 1,
+        repetitions=plan.fair_vote_max_repetitions,
+        requested=plan.comparison_metric_calls,
+    )
+    await _require_comparison_budget(
+        task,
+        candidates=2,
+        repetitions=plan.fair_vote_max_repetitions,
+        requested=plan.continuation_comparison_metric_calls,
+    )
+    if task.test_set is not None:
+        test_case_count = len(await task._test_cases_for_reporting())
+        if (
+            plan.reporting_metric_calls is not None
+            and plan.reporting_metric_calls < test_case_count
+        ):
+            raise ValueError(
+                "reporting_metric_calls cannot fund the held-out test_set."
+            )
+    phase_one_budget = BudgetTracker(plan.phase_one_metric_calls)
+    phase_one = await _run_parallel(task, plan.phase_one, phase_one_budget)
+    seed = await task.seed_candidate()
+    seed_result = EngineResult(
+        engine="seed",
+        best_candidate=seed,
+        best_score=0.0,
+        num_metric_calls=0,
+        history=[EngineEvent(kind="seed")],
+    )
+    comparable = [seed_result, *phase_one]
+    winner_index, votes, comparison_budget, decision = await _select_fair_winner(
+        task,
+        comparable,
+        metric_calls=plan.comparison_metric_calls,
+        repetitions=plan.fair_vote_repetitions,
+        max_repetitions=plan.fair_vote_max_repetitions,
+        mode=plan.selection_mode,
+        selection_rule=selection_rule,
+        confidence=plan.acceptance_confidence,
+        min_delta=plan.acceptance_min_delta,
+        baseline_index=0,
+    )
+    seed_result = seed_result.model_copy(update={"best_score": votes[0].mean_score})
+    comparable[0] = seed_result
+    if (
+        votes[winner_index].mean_score < votes[0].mean_score
+        or not votes[winner_index].selectable
+    ):
+        winner_index = 0
+        decision = {**decision, "seed_monotonic_override": True}
+    winner = comparable[winner_index]
+    # A fresh registry lookup (rather than reusing phase one) is intentional.
+    phase_two_budget = BudgetTracker(plan.phase_two_metric_calls)
+    seeded_task = cast(
+        OptimizationTask,
+        _SeededTask(
+            cast(OptimizationTask, _EngineTaskView(task)), winner.best_candidate
+        ),
+    )
+    continuation = await get_engine(plan.phase_two.engine, plan.phase_two).run(
+        seeded_task, plan.phase_two, phase_two_budget
+    )
+    _reconcile_engine_result(plan.phase_two, continuation, phase_two_budget)
+    (
+        continuation_winner_index,
+        continuation_votes,
+        continuation_budget,
+        continuation_decision,
+    ) = await _select_fair_winner(
+        task,
+        [winner, continuation],
+        metric_calls=plan.continuation_comparison_metric_calls,
+        repetitions=plan.fair_vote_repetitions,
+        max_repetitions=plan.fair_vote_max_repetitions,
+        mode=plan.selection_mode,
+        selection_rule=None,
+        confidence=plan.acceptance_confidence,
+        min_delta=plan.acceptance_min_delta,
+        baseline_index=0,
+    )
+    # A continuation is adopted only after the shared uncertainty-aware
+    # acceptance primitive cleared the configured practical delta.
+    adopted_continuation = (
+        continuation_winner_index == 1
+        and continuation_votes[1].selectable
+        and continuation_decision.get("acceptance", {}).get("verdict") == "accepted"
+    )
+    final = continuation if adopted_continuation else winner
+    test_case_count = (
+        len(await task._test_cases_for_reporting()) if task.test_set is not None else 0
+    )
+    final_budget = (
+        BudgetTracker(plan.reporting_metric_calls or test_case_count)
+        if test_case_count
+        else None
+    )
+    test_score: float | None = None
+    reporting_calls = 0
+    if test_case_count:
+        assert final_budget is not None
+        test = await task.evaluate(
+            final.best_candidate, budget=final_budget, dataset="test"
+        )
+        test_score = test.score
+        reporting_calls = test.num_cases
+    return PipelineResult(
+        results=[*comparable, continuation],
+        best=final,
+        best_index=len(comparable) if adopted_continuation else winner_index,
+        fair_scores=[vote.mean_score for vote in votes],
+        total_metric_calls=phase_one_budget.spent + phase_two_budget.spent,
+        comparison_metric_calls=comparison_budget.spent + continuation_budget.spent,
+        reporting_metric_calls=reporting_calls,
+        fair_votes=votes,
+        decision={
+            **decision,
+            "phase_two_engine": plan.phase_two.engine,
+            "phase_two_seeded_from": winner_index,
+            "phase_two_adopted": adopted_continuation,
+            "continuation_winner": continuation_winner_index,
+            "continuation_vote": continuation_decision,
+            "continuation_samples": [vote.model_dump() for vote in continuation_votes],
+        },
+        test_score=test_score,
+        phases=[
+            {
+                "phase": "explore",
+                "budget": plan.phase_one_metric_calls,
+                "engines": [config.engine for config in plan.phase_one],
+            },
+            {
+                "phase": "compare",
+                "budget": comparison_budget.max_metric_calls,
+                "winner": winner_index,
+            },
+            {
+                "phase": "continue",
+                "budget": plan.phase_two_metric_calls,
+                "engine": plan.phase_two.engine,
+                "fresh_instance": True,
+            },
+            {
+                "phase": "continuation_compare",
+                "budget": continuation_budget.max_metric_calls,
+            },
+        ],
+    )
+
+
+async def optimize_adaptive_sequential(
+    task: OptimizationTask,
+    configs: Sequence[EngineConfig],
+    *,
+    max_metric_calls: int,
+    plateau_min_improvement: float = 0.0,
+    comparison_metric_calls: int | None = None,
+    patience: int = 1,
+    min_evaluations_per_engine: int = 1,
+    max_switches: int | None = None,
+    cycle: bool = False,
+    max_slices: int | None = None,
+) -> PipelineResult:
+    """Run bounded fresh slices and switch only after observed plateaus."""
+    if not configs:
+        raise ValueError("At least one engine config is required.")
+    if patience < 1 or min_evaluations_per_engine < 1:
+        raise ValueError("patience and min_evaluations_per_engine must be positive.")
+    if not math.isfinite(plateau_min_improvement) or plateau_min_improvement < 0:
+        raise ValueError("plateau_min_improvement must be finite and non-negative.")
+    if max_switches is not None and max_switches < 0:
+        raise ValueError("max_switches must be non-negative.")
+    if max_slices is not None and max_slices < 1:
+        raise ValueError("max_slices must be positive.")
     budget = BudgetTracker(max_metric_calls)
-    results = await _run_parallel(task, configs, budget)
-    best_index, fair_scores = await _select_fair_winner(task, results)
-    return _pipeline_result(results, best_index, fair_scores, budget)
+    # One seed comparison plus one result comparison per possible slice.
+    # Defaults are driven by affordable fresh engine slices, not the number of
+    # engine families.  A first engine may improve for many slices before it
+    # plateaus; hard caps remain explicit through ``max_slices``.
+    smallest_slice = min(config.max_metric_calls for config in configs)
+    slice_limit = max_slices or max(1, max_metric_calls // smallest_slice)
+    possible_slices = slice_limit
+    cap = await _comparison_cap(task, possible_slices, 1, None, include_seed=True)
+    if comparison_metric_calls is not None and comparison_metric_calls < cap:
+        raise ValueError(
+            "comparison_metric_calls cannot fund all scheduled adaptive comparisons."
+        )
+    comparison = BudgetTracker(comparison_metric_calls or cap)
+    seed = await task.seed_candidate()
+    incumbent = await task.evaluate(seed, budget=comparison)
+    best = EngineResult(
+        engine="seed",
+        best_candidate=seed,
+        best_score=incumbent.score,
+        num_metric_calls=0,
+    )
+    results: list[EngineResult] = []
+    votes: list[FairVote] = []
+    phases: list[dict[str, Any]] = []
+    index = 0
+    switches = 0
+    plateau_rounds = 0
+    calls_for_engine = 0
+    while (
+        budget.remaining > 0
+        and len(results) < slice_limit
+        and (cycle or index < len(configs))
+    ):
+        config = configs[index % len(configs)]
+        slice_size = min(config.max_metric_calls, budget.remaining)
+        if slice_size < min_evaluations_per_engine:
+            break
+        local = budget.reserve_slice(slice_size)
+        try:
+            seeded = cast(
+                OptimizationTask,
+                _SeededTask(
+                    cast(OptimizationTask, _EngineTaskView(task)), best.best_candidate
+                ),
+            )
+            result = await get_engine(config.engine, config).run(seeded, config, local)
+            _reconcile_engine_result(config, result, local)
+        finally:
+            budget.release_slice(local)
+        results.append(result)
+        consumed = slice_size - local.remaining
+        observed = await task.evaluate(result.best_candidate, budget=comparison)
+        vote = FairVote(
+            candidate_index=len(results) - 1,
+            samples=[observed.score],
+            mean_score=observed.score,
+            objective_scores=observed.objective_scores,
+            per_case_scores=observed.per_case_scores,
+            per_case_objective_scores=observed.per_case_objective_scores,
+            selectable=observed.selectable,
+        )
+        votes.append(vote)
+        improved = (
+            observed.selectable
+            and observed.score > incumbent.score + plateau_min_improvement
+        )
+        if improved:
+            best = result
+            incumbent = observed
+            plateau_rounds = 0
+        else:
+            plateau_rounds += 1
+        # A driver that spends no metric calls has made no measurable search
+        # progress. Count it as a plateau so bounded scheduling cannot keep
+        # selecting it forever.
+        no_progress = consumed == 0
+        calls_for_engine += consumed
+        if no_progress:
+            plateau_rounds = max(plateau_rounds, patience)
+        switch = plateau_rounds >= patience and (
+            calls_for_engine >= min_evaluations_per_engine or no_progress
+        )
+        phases.append(
+            {
+                "stage": len(results) - 1,
+                "engine": config.engine,
+                "slice_metric_calls": slice_size,
+                "improved": improved,
+                "no_progress": no_progress,
+                "plateau": switch,
+                "incumbent_score": incumbent.score,
+            }
+        )
+        if switch:
+            # ``max_switches`` counts transitions that actually occur, not a
+            # final plateau observation that merely terminates the scheduler.
+            if max_switches is not None and switches >= max_switches:
+                break
+            index += 1
+            switches += 1
+            plateau_rounds = 0
+            calls_for_engine = 0
+        elif not cycle:
+            # Continue the active engine only when it improved; its next slice
+            # is a fresh instance seeded from the global incumbent.
+            index = index
+        else:
+            index = index
+        if not cycle and index >= len(configs):
+            break
+    best_index = -1 if best.engine == "seed" else results.index(best)
+    return PipelineResult(
+        results=results,
+        best=best,
+        best_index=best_index,
+        fair_scores=[vote.mean_score for vote in votes],
+        total_metric_calls=budget.spent,
+        comparison_metric_calls=comparison.spent,
+        fair_votes=votes,
+        phases=phases,
+        decision={
+            "kind": "adaptive_sequential",
+            "switches": switches,
+            "patience": patience,
+            "plateau_min_improvement": plateau_min_improvement,
+        },
+    )
 
 
 async def _run_parallel(
     task: OptimizationTask,
     configs: Sequence[EngineConfig],
     budget: BudgetTracker,
+    *,
+    legacy_fallback: bool = False,
 ) -> list[EngineResult]:
-    """Construct and concurrently run engines in configuration order."""
+    if not configs:
+        raise ValueError("At least one engine config is required.")
+    requested = sum(config.max_metric_calls for config in configs)
+    if requested > budget.remaining and legacy_fallback:
+        # Pre-Omni callers did not declare slices. Preserve their surface but
+        # serialize it: a mutable shared budget is never handed to concurrent
+        # engines, and each result is reconciled with actual consumption.
+        engines = [get_engine(config.engine, config) for config in configs]
+        results: list[EngineResult] = []
+        engine_task = cast(OptimizationTask, _EngineTaskView(task))
+        for engine, config in zip(engines, configs):
+            before = budget.spent
+            result = await engine.run(engine_task, config, budget)
+            if result.num_metric_calls != budget.spent - before:
+                raise RuntimeError(
+                    f"Engine {config.engine!r} reported {result.num_metric_calls} calls, "
+                    f"but consumed {budget.spent - before}."
+                )
+            results.append(result)
+        return results
+    if requested > budget.remaining:
+        raise ValueError(
+            f"Engine slices request {requested} metric calls but only {budget.remaining} are available."
+        )
+    slices = [budget.reserve_slice(config.max_metric_calls) for config in configs]
     engines = [get_engine(config.engine, config) for config in configs]
-    return list(
-        await asyncio.gather(
-            *(
-                engine.run(task, config, budget)
-                for engine, config in zip(engines, configs)
+    engine_task = cast(OptimizationTask, _EngineTaskView(task))
+    tasks = [
+        asyncio.create_task(engine.run(engine_task, config, local))
+        for engine, config, local in zip(engines, configs, slices)
+    ]
+    try:
+        results = list(await asyncio.gather(*tasks))
+        for config, result, local in zip(configs, results, slices):
+            _reconcile_engine_result(config, result, local)
+        return results
+    finally:
+        # ``gather`` propagates a sibling exception immediately.  Do not
+        # release a local slice while a cancelled sibling could still spend it.
+        unfinished_tasks = [pending for pending in tasks if not pending.done()]
+        for pending in unfinished_tasks:
+            pending.cancel()
+        if unfinished_tasks:
+            await asyncio.gather(*unfinished_tasks, return_exceptions=True)
+        for local in slices:
+            budget.release_slice(local)
+
+
+def _reconcile_engine_result(
+    config: EngineConfig, result: EngineResult, budget: BudgetTracker
+) -> None:
+    if result.num_metric_calls != budget.spent:
+        raise RuntimeError(
+            f"Engine {config.engine!r} reported {result.num_metric_calls} calls, "
+            f"but consumed {budget.spent} from its allocated budget."
+        )
+
+
+async def _select_fair_winner(
+    task: OptimizationTask,
+    results: Sequence[EngineResult],
+    *,
+    metric_calls: int | None,
+    repetitions: int,
+    max_repetitions: int,
+    mode: str,
+    selection_rule: SelectionRule | None,
+    confidence: float = 0.9,
+    min_delta: float = 0.0,
+    baseline_index: int | None = None,
+) -> tuple[int, list[FairVote], BudgetTracker, dict[str, Any]]:
+    if not results:
+        raise ValueError("At least one engine result is required.")
+    if not 1 <= repetitions <= max_repetitions <= 5:
+        raise ValueError(
+            "Fair voting requires 1 <= repetitions <= max_repetitions <= 5."
+        )
+    required = await _comparison_cap(task, len(results), max_repetitions, None)
+    if metric_calls is not None and metric_calls < required:
+        raise ValueError(
+            f"Fair comparison requires {required} metric calls for {max_repetitions} matched rounds; got {metric_calls}."
+        )
+    budget = BudgetTracker(metric_calls if metric_calls is not None else required)
+    evaluations: list[list[CandidateEvaluation]] = [[] for _ in results]
+    # Round-robin evaluation provides matched repetitions: every candidate sees
+    # the same immutable validation case order before anyone gets a tiebreak.
+    rounds = 0
+    for _ in range(repetitions):
+        for index, result in enumerate(results):
+            evaluations[index].append(
+                await task.evaluate(result.best_candidate, budget=budget)
             )
+        rounds += 1
+    votes = _votes(evaluations)
+    provisional, kind = _provisional_winner(votes, mode, selection_rule)
+    if baseline_index is None:
+        acceptance: dict[str, Any] = {"verdict": "not_applicable"}
+        continue_rounds = _requires_tiebreak(votes)
+    else:
+        if not 0 <= baseline_index < len(votes):
+            raise ValueError("baseline_index must reference a fair-vote candidate.")
+        if not votes[baseline_index].selectable:
+            raise ValueError(
+                "The frozen fair-vote baseline must be selectable on every matched round."
+            )
+        acceptance = _acceptance_for_candidate(
+            votes, baseline_index, provisional, confidence, min_delta
+        )
+        continue_rounds = (
+            provisional != baseline_index and acceptance["verdict"] == "inconclusive"
+        )
+    while continue_rounds and rounds < max_repetitions:
+        for index, result in enumerate(results):
+            evaluations[index].append(
+                await task.evaluate(result.best_candidate, budget=budget)
+            )
+        rounds += 1
+        votes = _votes(evaluations)
+        provisional, kind = _provisional_winner(votes, mode, selection_rule)
+        if baseline_index is None:
+            continue_rounds = _requires_tiebreak(votes)
+        else:
+            if not votes[baseline_index].selectable:
+                raise ValueError(
+                    "The frozen fair-vote baseline must be selectable on every matched round."
+                )
+            acceptance = _acceptance_for_candidate(
+                votes, baseline_index, provisional, confidence, min_delta
+            )
+            continue_rounds = (
+                provisional != baseline_index
+                and acceptance["verdict"] == "inconclusive"
+            )
+    winner = (
+        provisional
+        if baseline_index is None
+        or provisional == baseline_index
+        or acceptance["verdict"] == "accepted"
+        else baseline_index
+    )
+    return (
+        winner,
+        votes,
+        budget,
+        {
+            "kind": kind,
+            "repetitions": rounds,
+            "matched_case_order": True,
+            "baseline_index": baseline_index,
+            "provisional_winner": provisional,
+            "acceptance": acceptance,
+            "selectable_candidates": [
+                vote.candidate_index for vote in votes if vote.selectable
+            ],
+        },
+    )
+
+
+def _provisional_winner(
+    votes: Sequence[FairVote], mode: str, selection_rule: SelectionRule | None
+) -> tuple[int, str]:
+    """Select a Pareto/custom provisional winner before baseline acceptance."""
+    if selection_rule is not None:
+        winner = selection_rule(votes)
+        if not 0 <= winner < len(votes) or not votes[winner].selectable:
+            raise ValueError("selection_rule must choose a selectable candidate index.")
+        return winner, "custom"
+    return _select_vote(votes, mode), mode
+
+
+def _acceptance_for_candidate(
+    votes: Sequence[FairVote],
+    baseline_index: int,
+    candidate_index: int,
+    confidence: float,
+    min_delta: float,
+) -> dict[str, Any]:
+    """Run the one shared acceptance primitive against the durable baseline."""
+    if candidate_index == baseline_index:
+        return {
+            "verdict": "baseline",
+            "confidence": confidence,
+            "min_delta": min_delta,
+        }
+    return compare_candidate_samples(
+        votes[baseline_index].samples,
+        votes[candidate_index].samples,
+        confidence=confidence,
+        min_delta=min_delta,
+    ).to_dict()
+
+
+def _votes(evaluations: Sequence[Sequence[CandidateEvaluation]]) -> list[FairVote]:
+    for samples in evaluations:
+        _require_matching_coordinates(samples)
+    if evaluations:
+        coordinate_sets = [
+            _coordinate_set(samples[0]) for samples in evaluations if samples
+        ]
+        if len(coordinate_sets) != len(evaluations) or any(
+            coordinates != coordinate_sets[0] for coordinates in coordinate_sets[1:]
+        ):
+            raise ValueError(
+                "Matched fair-vote candidates must expose identical scalar and objective coordinates."
+            )
+    return [
+        FairVote(
+            candidate_index=index,
+            samples=[evaluation.score for evaluation in samples],
+            mean_score=sum(evaluation.score for evaluation in samples) / len(samples),
+            objective_scores=_mean_objectives(samples),
+            per_case_scores=_mean_per_case_scores(samples),
+            per_case_objective_scores=_mean_per_case_objectives(samples),
+            selectable=all(evaluation.selectable for evaluation in samples),
+        )
+        for index, samples in enumerate(evaluations)
+    ]
+
+
+def _require_matching_coordinates(samples: Sequence[CandidateEvaluation]) -> None:
+    if not samples:
+        return
+    first = _coordinate_set(samples[0])
+    for sample in samples[1:]:
+        if _coordinate_set(sample) != first:
+            raise ValueError(
+                "Matched fair-vote samples must expose identical scalar and objective coordinates."
+            )
+
+
+def _coordinate_set(
+    evaluation: CandidateEvaluation,
+) -> tuple[frozenset[str], frozenset[str], frozenset[tuple[str, str]]]:
+    return (
+        frozenset(evaluation.per_case_scores),
+        frozenset(evaluation.objective_scores),
+        frozenset(
+            (case_id, name)
+            for case_id, values in evaluation.per_case_objective_scores.items()
+            for name in values
+        ),
+    )
+
+
+def _mean_objectives(samples: Sequence[CandidateEvaluation]) -> dict[str, float]:
+    values: dict[str, list[float]] = {}
+    for sample in samples:
+        for name, value in sample.objective_scores.items():
+            values.setdefault(name, []).append(value)
+    return {name: sum(numbers) / len(numbers) for name, numbers in values.items()}
+
+
+def _mean_per_case_scores(samples: Sequence[CandidateEvaluation]) -> dict[str, float]:
+    values: dict[str, list[float]] = {}
+    for sample in samples:
+        for case_id, score in sample.per_case_scores.items():
+            values.setdefault(case_id, []).append(score)
+    return {case_id: sum(scores) / len(scores) for case_id, scores in values.items()}
+
+
+def _mean_per_case_objectives(
+    samples: Sequence[CandidateEvaluation],
+) -> dict[str, dict[str, float]]:
+    values: dict[str, dict[str, list[float]]] = {}
+    for sample in samples:
+        for case_id, objectives in sample.per_case_objective_scores.items():
+            for name, score in objectives.items():
+                values.setdefault(case_id, {}).setdefault(name, []).append(score)
+    return {
+        case_id: {
+            name: sum(scores) / len(scores) for name, scores in objectives.items()
+        }
+        for case_id, objectives in values.items()
+    }
+
+
+def _requires_tiebreak(votes: Sequence[FairVote]) -> bool:
+    selectable = [vote for vote in votes if vote.selectable]
+    if len(selectable) < 2:
+        return False
+    ordered = sorted(selectable, key=lambda vote: vote.mean_score, reverse=True)
+    return abs(ordered[0].mean_score - ordered[1].mean_score) < 1e-12
+
+
+def _select_vote(votes: Sequence[FairVote], mode: str) -> int:
+    selectable = [vote for vote in votes if vote.selectable]
+    if not selectable:
+        raise ValueError("No selectable candidate was produced by the fair comparison.")
+    if mode != "instance" and any(
+        _frontier_coordinates(vote, mode) is None for vote in selectable
+    ):
+        raise ValueError(
+            f"{mode} selection requires complete objective scores for every selectable candidate."
+        )
+    coordinates = [_frontier_coordinates(vote, mode) for vote in selectable]
+    if any(coordinate is None for coordinate in coordinates) or any(
+        coordinate is None or set(coordinate) != set(coordinates[0] or {})
+        for coordinate in coordinates[1:]
+    ):
+        raise ValueError(
+            "Fair-vote candidates must have identical frontier coordinates."
+        )
+    nondominated = [
+        vote
+        for vote in selectable
+        if not any(
+            _dominates(other, vote, mode) for other in selectable if other is not vote
+        )
+    ]
+    return max(
+        nondominated, key=lambda vote: (vote.mean_score, -vote.candidate_index)
+    ).candidate_index
+
+
+def _dominates(left: FairVote, right: FairVote, mode: str) -> bool:
+    coordinates_left = _frontier_coordinates(left, mode)
+    coordinates_right = _frontier_coordinates(right, mode)
+    if (
+        coordinates_left is None
+        or coordinates_right is None
+        or set(coordinates_left) != set(coordinates_right)
+    ):
+        return False
+    return (
+        bool(coordinates_left)
+        and all(
+            coordinates_left[key] >= coordinates_right[key] for key in coordinates_left
+        )
+        and any(
+            coordinates_left[key] > coordinates_right[key] for key in coordinates_left
         )
     )
 
 
-async def _select_fair_winner(
-    task: OptimizationTask, results: Sequence[EngineResult]
-) -> tuple[int, list[float]]:
-    """Return the earliest result with the highest uncharged full-valset score."""
-    if not results:
-        raise ValueError("At least one engine result is required.")
-    fair_scores = [
-        (await task.evaluate(result.best_candidate, budget=None)).score
-        for result in results
-    ]
-    return max(
-        range(len(fair_scores)), key=lambda index: fair_scores[index]
-    ), fair_scores
+def _frontier_coordinates(vote: FairVote, mode: str) -> dict[str, float] | None:
+    if mode not in {"instance", "objective", "hybrid", "cartesian"}:
+        raise ValueError(
+            "selection mode must be instance, objective, hybrid, or cartesian."
+        )
+    coordinates: dict[str, float] = {}
+    if mode in {"instance", "hybrid"}:
+        coordinates.update(
+            {
+                f"case:{case_id}": score
+                for case_id, score in vote.per_case_scores.items()
+            }
+        )
+    if mode in {"objective", "hybrid"}:
+        if not vote.objective_scores:
+            return None
+        coordinates.update(
+            {
+                f"objective:{name}": score
+                for name, score in vote.objective_scores.items()
+            }
+        )
+    if mode == "cartesian":
+        for case_id, objectives in vote.per_case_objective_scores.items():
+            for name, score in objectives.items():
+                coordinates[f"case:{case_id}:objective:{name}"] = score
+        if not coordinates:
+            return None
+    return coordinates or None
+
+
+async def _comparison_cap(
+    task: OptimizationTask,
+    candidates: int,
+    repetitions: int,
+    requested: int | None,
+    *,
+    include_seed: bool = False,
+) -> int:
+    """Resolve the named comparison budget from the fixed validation set."""
+    if requested is not None:
+        return requested
+    return len(await task._validation_cases()) * (
+        candidates * repetitions + int(include_seed)
+    )
+
+
+async def _require_comparison_budget(
+    task: OptimizationTask,
+    *,
+    candidates: int,
+    repetitions: int,
+    requested: int | None,
+    include_seed: bool = False,
+) -> int:
+    """Resolve and preflight a full matched comparison before work begins."""
+    required = await _comparison_cap(
+        task, candidates, repetitions, None, include_seed=include_seed
+    )
+    if requested is not None and requested < required:
+        raise ValueError(
+            f"comparison_metric_calls cannot fund {required} required matched metric calls; got {requested}."
+        )
+    return requested if requested is not None else required
 
 
 def _pipeline_result(
     results: list[EngineResult],
-    best_index: int,
-    fair_scores: list[float],
+    index: int,
+    votes: list[FairVote],
     budget: BudgetTracker,
+    comparison_budget: BudgetTracker,
+    decision: dict[str, Any],
 ) -> PipelineResult:
-    """Build a public result without exposing the mutable budget tracker."""
     return PipelineResult(
         results=results,
-        best=results[best_index],
-        best_index=best_index,
-        fair_scores=fair_scores,
+        best=results[index],
+        best_index=index,
+        fair_scores=[vote.mean_score for vote in votes],
         total_metric_calls=budget.spent,
+        comparison_metric_calls=comparison_budget.spent,
+        fair_votes=votes,
+        decision=decision,
     )
 
 
 __all__ = [
+    "FairVote",
+    "OmniPlan",
     "PipelineResult",
+    "SelectionRule",
+    "optimize_adaptive_sequential",
     "optimize_best_of",
+    "optimize_omni",
     "optimize_parallel",
     "optimize_sequential",
     "optimize_vote",

--- a/src/pydantic_ai_gepa/engines/__init__.py
+++ b/src/pydantic_ai_gepa/engines/__init__.py
@@ -20,11 +20,14 @@ from .registry import (
 from .gepa_engine import GepaEngine
 from .coding_agent_engine import CodingAgentEngine, Proposer, ReflectionContext
 from .best_of_n import BestOfNEngine
+from .autoresearch_engine import AutonomousResearchDriver, AutonomousResearchEngine
 
 __all__ = [
     "BudgetExhausted",
     "BudgetTracker",
     "BestOfNEngine",
+    "AutonomousResearchDriver",
+    "AutonomousResearchEngine",
     "CandidateEvaluation",
     "CodingAgentEngine",
     "EngineConfig",

--- a/src/pydantic_ai_gepa/engines/autoresearch_engine.py
+++ b/src/pydantic_ai_gepa/engines/autoresearch_engine.py
@@ -1,0 +1,55 @@
+"""Autonomous-research engine seam for caller-owned long-horizon loops."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias, cast
+
+from .base import BudgetTracker, EngineConfig, EngineResult, OptimizationTask
+from .registry import register_engine
+
+
+AutonomousResearchDriver: TypeAlias = Callable[
+    [OptimizationTask, EngineConfig, BudgetTracker], Awaitable[EngineResult]
+]
+
+
+class AutonomousResearchEngine:
+    """Delegate an autonomous optimization loop without hardcoding an agent CLI.
+
+    The driver owns its long-lived coding-agent/eval-server interaction and
+    must consume the supplied budget. This keeps vendor/model process policy
+    out of the library while retaining the common result/accounting contract.
+    """
+
+    name = "autoresearch"
+
+    def __init__(self, config: EngineConfig) -> None:
+        driver = config.engine_config.get("driver")
+        if not callable(driver):
+            raise TypeError(
+                "engine_config['driver'] must be an async callable accepting "
+                "(OptimizationTask, EngineConfig, BudgetTracker)."
+            )
+        self._driver = cast(AutonomousResearchDriver, driver)
+
+    async def run(
+        self, task: OptimizationTask, config: EngineConfig, budget: BudgetTracker
+    ) -> EngineResult:
+        before = budget.spent
+        result = await self._driver(task, config, budget)
+        consumed = budget.spent - before
+        if result.num_metric_calls != consumed:
+            raise RuntimeError(
+                "Autonomous-research driver accounting mismatch: its EngineResult "
+                f"reports {result.num_metric_calls}, but it spent {consumed}."
+            )
+        if result.engine != self.name:
+            return result.model_copy(update={"engine": self.name})
+        return result
+
+
+register_engine(AutonomousResearchEngine.name, AutonomousResearchEngine, replace=True)
+
+
+__all__ = ["AutonomousResearchDriver", "AutonomousResearchEngine"]

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Generator
 from typing import Any
 
@@ -11,6 +12,7 @@ from pydantic_ai.models.test import TestModel
 from pydantic_evals import Case
 
 from pydantic_ai_gepa.compose import (
+    optimize_adaptive_sequential,
     optimize_best_of,
     optimize_parallel,
     optimize_sequential,
@@ -59,6 +61,20 @@ class _FakeEngine:
         budget: BudgetTracker,
     ) -> EngineResult:
         options = config.engine_config
+        started = options.get("started")
+        if isinstance(started, asyncio.Event):
+            started.set()
+        if options.get("raise_error"):
+            raise RuntimeError("engine failure")
+        wait_for = options.get("wait_for")
+        if isinstance(wait_for, asyncio.Event):
+            try:
+                await wait_for.wait()
+            except asyncio.CancelledError:
+                cancelled = options.get("cancelled")
+                if isinstance(cancelled, asyncio.Event):
+                    cancelled.set()
+                raise
         seen = options.get("seen_seeds")
         if isinstance(seen, list):
             seen.append((await task.seed_candidate())["instructions"].text)
@@ -86,6 +102,8 @@ def _config(
     reported_score: float = 0.0,
     spend: int = 0,
     seen_seeds: list[str] | None = None,
+    max_metric_calls: int = 200,
+    **extra: Any,
 ) -> EngineConfig:
     options: dict[str, Any] = {
         "candidate": candidate,
@@ -94,7 +112,12 @@ def _config(
     }
     if seen_seeds is not None:
         options["seen_seeds"] = seen_seeds
-    return EngineConfig(engine=_ENGINE_NAME, engine_config=options)
+    options.update(extra)
+    return EngineConfig(
+        engine=_ENGINE_NAME,
+        max_metric_calls=max_metric_calls,
+        engine_config=options,
+    )
 
 
 @pytest.mark.asyncio
@@ -112,6 +135,82 @@ async def test_optimize_parallel_preserves_order_and_shares_its_budget() -> None
 
 
 @pytest.mark.asyncio
+async def test_parallel_cancels_and_awaits_siblings_before_releasing_slices() -> None:
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    never = asyncio.Event()
+    with pytest.raises(RuntimeError, match="engine failure"):
+        await optimize_parallel(
+            _task(),
+            [
+                _config(_candidate("bad"), raise_error=True),
+                _config(
+                    _candidate("slow"),
+                    seen_seeds=[],
+                    wait_for=never,
+                    started=started,
+                    cancelled=cancelled,
+                ),
+            ],
+            max_metric_calls=2,
+        )
+    # The implementation waits for cancellation; it cannot return while a
+    # sibling could still use its released local slice.
+    assert cancelled.is_set() or not started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_adaptive_sequential_uses_affordable_slices_and_switches_on_plateau() -> (
+    None
+):
+    seen_seeds: list[str] = []
+    result = await optimize_adaptive_sequential(
+        _task(),
+        [
+            _config(
+                _candidate("correct"),
+                spend=1,
+                seen_seeds=seen_seeds,
+                max_metric_calls=1,
+            ),
+            _config(
+                _candidate("wrong"),
+                spend=1,
+                seen_seeds=seen_seeds,
+                max_metric_calls=1,
+            ),
+        ],
+        max_metric_calls=4,
+        patience=1,
+        max_switches=1,
+    )
+    # The first slice improves, its second equal-score slice plateaus, then
+    # the scheduler reaches the next fresh engine instead of capping at two
+    # configured families.
+    assert len(result.results) >= 3
+    assert [phase["engine"] for phase in result.phases][-1] == _ENGINE_NAME
+    assert result.total_metric_calls >= 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [("plateau_min_improvement", -0.1), ("max_switches", -1), ("max_slices", 0)],
+)
+async def test_adaptive_rejects_invalid_bounds_before_work(
+    keyword: str, value: float | int
+) -> None:
+    arguments: dict[str, Any] = {keyword: value}
+    with pytest.raises(ValueError):
+        await optimize_adaptive_sequential(
+            _task(),
+            [_config(_candidate("correct"))],
+            max_metric_calls=1,
+            **arguments,
+        )
+
+
+@pytest.mark.asyncio
 async def test_optimize_best_of_uses_fair_valset_scores_not_reported_scores() -> None:
     low_actual = _config(_candidate("wrong"), reported_score=99.0)
     high_actual = _config(_candidate("correct"), reported_score=-1.0)
@@ -125,6 +224,46 @@ async def test_optimize_best_of_uses_fair_valset_scores_not_reported_scores() ->
     assert result.fair_scores == [0.0, 1.0]
     assert [item.best_score for item in result.results] == [99.0, -1.0]
     assert result.total_metric_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_best_of_noisy_vote_is_not_anchored_to_first_engine() -> None:
+    agent = Agent(TestModel(custom_output_text="response"), instructions="seed")
+    case = Case(name="case", inputs="input", expected_output="response")
+    samples = {"low": iter([0.4, 0.6]), "high": iter([0.45, 0.65])}
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        del case, output
+        active = agent._override_instructions.get()
+        text = str(active.value if active is not None else agent._instructions)
+        key = "high" if "high" in text else "low"
+        return MetricResult(score=next(samples[key]))
+
+    task = OptimizationTask(agent=agent, trainset=[case], valset=[case], metric=metric)
+    result = await optimize_best_of(
+        task,
+        [_config(_candidate("low")), _config(_candidate("high"))],
+        max_metric_calls=2,
+        fair_vote_repetitions=2,
+        fair_vote_max_repetitions=2,
+    )
+
+    assert result.best_index == 1
+    assert result.decision["baseline_index"] is None
+    assert result.decision["acceptance"]["verdict"] == "not_applicable"
+
+
+@pytest.mark.asyncio
+async def test_underfunded_comparison_fails_before_an_engine_can_run() -> None:
+    seen: list[str] = []
+    with pytest.raises(ValueError, match="cannot fund"):
+        await optimize_best_of(
+            _task(),
+            [_config(_candidate("correct"), seen_seeds=seen)],
+            max_metric_calls=1,
+            comparison_metric_calls=0,
+        )
+    assert seen == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_omni.py
+++ b/tests/test_omni.py
@@ -1,0 +1,406 @@
+"""Deterministic coverage for the first-class Omni composition contract."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+from pydantic_evals import Case
+
+from pydantic_ai_gepa.compose import OmniPlan, optimize_omni
+from pydantic_ai_gepa.engines import (
+    BudgetTracker,
+    EngineConfig,
+    EngineResult,
+    OptimizationTask,
+    register_engine,
+    unregister_engine,
+)
+from pydantic_ai_gepa.gepa_graph.models import CandidateMap, ComponentValue
+from pydantic_ai_gepa.types import MetricResult, RolloutOutput
+
+
+def _candidate(text: str) -> CandidateMap:
+    return {"instructions": ComponentValue(name="instructions", text=text)}
+
+
+class _OmniFake:
+    name = "omni_fake"
+
+    def __init__(self, config: EngineConfig) -> None:
+        self.config = config
+
+    async def run(
+        self, task: OptimizationTask, config: EngineConfig, budget: BudgetTracker
+    ) -> EngineResult:
+        seen = config.engine_config.get("seen")
+        if isinstance(seen, list):
+            seen.append((await task.seed_candidate())["instructions"].text)
+        spend = int(config.engine_config.get("spend", 0))
+        budget.spend(spend)
+        return EngineResult(
+            engine=self.name,
+            best_candidate=config.engine_config["candidate"],
+            best_score=0,
+            num_metric_calls=spend,
+        )
+
+
+class _TestSetProbe:
+    name = "test_set_probe"
+
+    def __init__(self, config: EngineConfig) -> None:
+        pass
+
+    async def run(
+        self, task: OptimizationTask, config: EngineConfig, budget: BudgetTracker
+    ) -> EngineResult:
+        assert task.test_set is None
+        with pytest.raises(PermissionError):
+            await task.evaluate(await task.seed_candidate(), dataset="test")
+        return EngineResult(
+            engine=self.name,
+            best_candidate=await task.seed_candidate(),
+            best_score=0,
+            num_metric_calls=0,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _registry() -> Generator[None, None, None]:
+    register_engine("omni_fake", _OmniFake, replace=True)
+    register_engine("omni_fake_2", _OmniFake, replace=True)
+    register_engine("test_set_probe", _TestSetProbe, replace=True)
+    yield
+    unregister_engine("omni_fake")
+    unregister_engine("omni_fake_2")
+    unregister_engine("test_set_probe")
+
+
+def _task(*, test_set: bool = False) -> OptimizationTask:
+    agent = Agent(TestModel(custom_output_text="ok"), instructions="seed")
+    cases = [Case(name="a", inputs="x", expected_output="ok")]
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        active = agent._override_instructions.get()
+        text = str(active.value if active else agent._instructions)
+        return MetricResult(
+            score=float("good" in text),
+            side_info={"scores": {"reliability": float("good" in text)}},
+        )
+
+    return OptimizationTask(
+        agent=agent,
+        trainset=cases,
+        valset=cases,
+        test_set=cases if test_set else None,
+        metric=metric,
+    )
+
+
+def _objective_task() -> OptimizationTask:
+    agent = Agent(TestModel(custom_output_text="ok"), instructions="seed")
+    cases = [Case(name="a", inputs="x", expected_output="ok")]
+    values = {
+        "seed": (0.1, 0.0),
+        "good": (0.5, 1.0),
+        "continuation": (0.6, 0.0),
+        "better": (0.55, 2.0),
+    }
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        override = agent._override_instructions.get()
+        text = str(override.value if override else agent._instructions)
+        key = next(name for name in values if name in text)
+        score, objective = values[key]
+        return MetricResult(score=score, side_info={"scores": {"quality": objective}})
+
+    return OptimizationTask(agent=agent, trainset=cases, valset=cases, metric=metric)
+
+
+def _noisy_task(values: dict[str, list[float]]) -> OptimizationTask:
+    """Return deterministic stochastic samples keyed by the active candidate."""
+    agent = Agent(TestModel(custom_output_text="ok"), instructions="seed")
+    case = Case(name="a", inputs="x", expected_output="ok")
+    samples = {name: iter(scores) for name, scores in values.items()}
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        del case, output
+        override = agent._override_instructions.get()
+        text = str(override.value if override else agent._instructions)
+        key = next(name for name in samples if name in text)
+        return MetricResult(score=next(samples[key]))
+
+    return OptimizationTask(agent=agent, trainset=[case], valset=[case], metric=metric)
+
+
+@pytest.mark.asyncio
+async def test_omni_uses_matched_slices_repeated_vote_and_fresh_phase_two_seed() -> (
+    None
+):
+    seen: list[str] = []
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake_2",
+                max_metric_calls=2,
+                engine_config={"candidate": _candidate("bad"), "spend": 1},
+            ),
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=2,
+                engine_config={"candidate": _candidate("good"), "spend": 1},
+            ),
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=2,
+            engine_config={
+                "candidate": _candidate("good final"),
+                "spend": 1,
+                "seen": seen,
+            },
+        ),
+        phase_one_metric_calls=4,
+        phase_two_metric_calls=2,
+        fair_vote_repetitions=3,
+        fair_vote_max_repetitions=3,
+    )
+
+    result = await optimize_omni(_task(), plan)
+
+    assert [len(vote.samples) for vote in result.fair_votes] == [3, 3, 3]
+    assert seen == ["good"]
+    # Exact ties retain the incumbent, consistent with the outer controller's
+    # deterministic scalar/identifier tie-break.
+    assert result.decision["phase_two_adopted"] is False
+    assert result.total_metric_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_omni_keeps_seed_when_phase_two_regresses_and_reports_held_out_test() -> (
+    None
+):
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=1,
+                engine_config={"candidate": _candidate("good"), "spend": 0},
+            )
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate("bad"), "spend": 0},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        fair_vote_repetitions=1,
+        fair_vote_max_repetitions=1,
+    )
+    result = await optimize_omni(_task(test_set=True), plan)
+    assert result.best.best_candidate["instructions"].text == "good"
+    assert result.test_score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_omni_hides_held_out_test_set_from_engine() -> None:
+    plan = OmniPlan(
+        phase_one=[EngineConfig(engine="test_set_probe", max_metric_calls=1)],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate("good")},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        fair_vote_repetitions=1,
+        fair_vote_max_repetitions=1,
+    )
+    await optimize_omni(_task(test_set=True), plan)
+
+
+@pytest.mark.asyncio
+async def test_omni_preflights_comparison_before_phase_one_engine_work() -> None:
+    seen: list[str] = []
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=1,
+                engine_config={"candidate": _candidate("good"), "seen": seen},
+            )
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate("good")},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        comparison_metric_calls=1,
+        continuation_comparison_metric_calls=1,
+        fair_vote_repetitions=1,
+        fair_vote_max_repetitions=1,
+    )
+    with pytest.raises(ValueError, match="cannot fund"):
+        await optimize_omni(_task(), plan)
+    assert seen == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("continuation", "expected", "adopted"),
+    [("continuation", "good", False), ("better", "better", True)],
+)
+async def test_omni_phase_two_obeys_objective_frontier_not_scalar_only(
+    continuation: str, expected: str, adopted: bool
+) -> None:
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=1,
+                engine_config={"candidate": _candidate("good")},
+            )
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate(continuation)},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        fair_vote_repetitions=1,
+        fair_vote_max_repetitions=1,
+        selection_mode="objective",
+    )
+    result = await optimize_omni(_objective_task(), plan)
+    assert result.best.best_candidate["instructions"].text == expected
+    assert result.decision["phase_two_adopted"] is adopted
+
+
+@pytest.mark.asyncio
+async def test_omni_keeps_seed_after_inconclusive_noisy_phase_one_vote() -> None:
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=1,
+                engine_config={"candidate": _candidate("challenger")},
+            )
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate("phase-two")},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        fair_vote_repetitions=2,
+        fair_vote_max_repetitions=3,
+    )
+    task = _noisy_task(
+        {
+            "seed": [0.4, 0.6, 0.5, 0.5, 0.5],
+            "challenger": [0.45, 0.65, 0.55],
+            "phase-two": [0.5, 0.5],
+        }
+    )
+
+    result = await optimize_omni(task, plan)
+
+    assert result.decision["acceptance"]["verdict"] == "inconclusive"
+    assert result.decision["repetitions"] == 3
+    assert result.decision["phase_two_seeded_from"] == 0
+
+
+@pytest.mark.asyncio
+async def test_omni_keeps_incumbent_after_inconclusive_noisy_phase_two_vote() -> None:
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=1,
+                engine_config={"candidate": _candidate("good")},
+            )
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate("continuation")},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        fair_vote_repetitions=2,
+        fair_vote_max_repetitions=2,
+    )
+    task = _noisy_task(
+        {
+            "seed": [0.0, 0.0],
+            "good": [0.8, 1.0, 0.8, 1.0],
+            "continuation": [0.85, 1.05],
+        }
+    )
+
+    result = await optimize_omni(task, plan)
+
+    assert result.best.best_candidate["instructions"].text == "good"
+    assert (
+        result.decision["continuation_vote"]["acceptance"]["verdict"] == "inconclusive"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omni_fails_closed_when_the_frozen_baseline_is_not_selectable() -> None:
+    agent = Agent(TestModel(custom_output_text="ok"), instructions="seed")
+    case = Case(name="a", inputs="x", expected_output="ok")
+
+    def metric(case: Case[str, str, Any], output: RolloutOutput[Any]) -> MetricResult:
+        del case, output
+        active = agent._override_instructions.get()
+        text = str(active.value if active else agent._instructions)
+        return MetricResult(
+            score=float("good" in text),
+            side_info={"selectable": "seed" not in text},
+        )
+
+    task = OptimizationTask(agent=agent, trainset=[case], valset=[case], metric=metric)
+    plan = OmniPlan(
+        phase_one=[
+            EngineConfig(
+                engine="omni_fake",
+                max_metric_calls=1,
+                engine_config={"candidate": _candidate("good")},
+            )
+        ],
+        phase_two=EngineConfig(
+            engine="omni_fake",
+            max_metric_calls=1,
+            engine_config={"candidate": _candidate("good")},
+        ),
+        phase_one_metric_calls=1,
+        phase_two_metric_calls=1,
+        fair_vote_repetitions=1,
+        fair_vote_max_repetitions=1,
+    )
+
+    with pytest.raises(ValueError, match="baseline must be selectable"):
+        await optimize_omni(task, plan)
+
+
+def test_omni_rejects_unmatched_slices_before_work() -> None:
+    with pytest.raises(ValueError, match="matched"):
+        OmniPlan(
+            phase_one=[
+                EngineConfig(engine="omni_fake", max_metric_calls=1),
+                EngineConfig(engine="omni_fake_2", max_metric_calls=2),
+            ],
+            phase_two=EngineConfig(engine="omni_fake", max_metric_calls=1),
+            phase_one_metric_calls=3,
+            phase_two_metric_calls=1,
+        )


### PR DESCRIPTION
## Summary
- add composable two-phase Omni optimization
- compare independent phase-one engines fairly on matched samples
- seed a fresh phase-two optimizer only from an accepted winner

## Stack
3 of 5; depends on #35.

## Verification
- full stack: 601 tests passed
- Ruff format and lint passed
- changed-file Pyright passed